### PR TITLE
Use elfutil's libdwfl to figure out address of executor_globals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: phpspy
 
 phpspy: phpspy.c
-	$(CC) -Wall -Wextra -g -I. phpspy.c -o phpspy
+	$(CC) -Wall -Wextra -ldw -g -I. phpspy.c -o phpspy
 
 phpspy_zend: phpspy.c
-	$(CC) -Wall -Wextra -g $$(php-config --includes) -DUSE_ZEND=1 -I. phpspy.c -o phpspy
+	$(CC) -Wall -Wextra -ldw -g $$(php-config --includes) -DUSE_ZEND=1 -I. phpspy.c -o phpspy
 
 clean:
 	rm -f phpspy


### PR DESCRIPTION
Extremely skimpy documentation is here: https://android.googlesource.com/platform/external/elfutils/+/master/libdwfl/libdwfl.h

Lots of trial and error, but this works!