### PR TITLE
add option to specify sample rate in hertz

### DIFF
--- a/phpspy.c
+++ b/phpspy.c
@@ -26,7 +26,7 @@
 #define PHPSPY_MIN(a, b) ((a) < (b) ? (a) : (b))
 
 pid_t opt_pid = -1;
-long opt_sleep_ns = 10000000; // 10ms
+long opt_sleep_ns = 10000000; // 10ms, 100Hz
 unsigned long long opt_executor_globals_addr = 0;
 unsigned long long opt_sapi_globals_addr = 0;
 int opt_capture_req = 0;
@@ -76,6 +76,7 @@ static void usage(FILE *fp, int exit_code) {
     fprintf(fp, "-h         Show help\n");
     fprintf(fp, "-p <pid>   Trace PHP process at pid\n");
     fprintf(fp, "-s <ns>    Sleep this many nanoseconds between traces (default: 10000000, 10ms)\n");
+    fprintf(fp, "-H <hz>    The rate at which frequency traces are recorded (default: 100hz)\n");
     fprintf(fp, "-n <max>   Set max stack trace depth to `max` (default: -1, unlimited)\n");
     fprintf(fp, "-x <hex>   Address of executor_globals in hex (default: 0, find dynamically)\n");
     fprintf(fp, "-a <hex>   Address of sapi_globals in hex (default: 0, find dynamically)\n");
@@ -94,11 +95,12 @@ static void usage(FILE *fp, int exit_code) {
 
 static void parse_opts(int argc, char **argv) {
     int c;
-    while ((c = getopt(argc, argv, "hp:s:n:x:a:rR:l:o:O:E:SV:1#:")) != -1) {
+    while ((c = getopt(argc, argv, "hp:s:H:n:x:a:rR:l:o:O:E:SV:1#:")) != -1) {
         switch (c) {
             case 'h': usage(stdout, 0); break;
             case 'p': opt_pid = atoi(optarg); break;
             case 's': opt_sleep_ns = strtol(optarg, NULL, 10); break;
+            case 'H': opt_sleep_ns = (1000000000ULL / strtol(optarg, NULL, 10)); break;
             case 'n': opt_max_stack_depth = atoi(optarg); break;
             case 'x': opt_executor_globals_addr = strtoull(optarg, NULL, 16); break;
             case 'a': opt_executor_globals_addr = strtoull(optarg, NULL, 16); break;


### PR DESCRIPTION
closes #11 

tested with: 

```php
<?php // tester.php


function say_hello() {
    echo "hello";
}

while (true) {
    say_hello();
    sleep(1);
}
```

got roughly the same amount of traces for nanoseconds vs. the equivalent value in hertz

```shellsession
$ sudo ./phpspy -- php ~/tester.php > nanoseconds.log & sleep 5 ; sudo pkill phpspy # default nanoseconds argument
[3] 11540
[3]   Exit 143                sudo ./phpspy -- php ~/tester.php > nanoseconds.log
$ sudo ./phpspy -R 100 -- php ~/tester.php > hertz.log & sleep 5 ; sudo pkill phpspy # equivalent argument in hertz
[3] 11616
[3]   Exit 143                sudo ./phpspy -R 100 -- php ~/tester.php > hertz.log
$ wc -l nanoseconds.log # trace count nanoseconds
1572 nanoseconds.log
$ wc -l hertz.log # trace count hertz
1520 hertz.log
```