### PR TITLE
add ability to print php $_SERVER values

### DIFF
--- a/addr_readelf.c
+++ b/addr_readelf.c
@@ -1,12 +1,12 @@
 static int get_php_bin_path(pid_t pid, char *path);
-static int get_php_base_addr(pid_t pid, char *path, unsigned long long *raddr);
-static int get_symbol_offset(char *path, const char *symbol, unsigned long long *raddr);
+static int get_php_base_addr(pid_t pid, char *path, uint64_t *raddr);
+static int get_symbol_offset(char *path, const char *symbol, uint64_t *raddr);
 static int popen_read_line(char *buf, size_t buf_size, char *cmd_fmt, ...);
 
-static int get_symbol_addr(pid_t pid, const char *symbol, unsigned long long *raddr) {
+static int get_symbol_addr(pid_t pid, const char *symbol, uint64_t *raddr) {
     char php_bin_path[128];
-    unsigned long long base_addr;
-    unsigned long long addr_offset;
+    uint64_t base_addr;
+    uint64_t addr_offset;
     if (get_php_bin_path(pid, php_bin_path) != 0) {
         return 1;
     } else if (get_php_base_addr(pid, php_bin_path, &base_addr) != 0) {
@@ -29,7 +29,7 @@ static int get_php_bin_path(pid_t pid, char *path) {
     return 0;
 }
 
-static int get_php_base_addr(pid_t pid, char *path, unsigned long long *raddr) {
+static int get_php_base_addr(pid_t pid, char *path, uint64_t *raddr) {
     /**
      * This is very likely to be incorrect/incomplete. I thought the base
      * address from `/proc/<pid>/maps` + the symbol address from `readelf` would
@@ -40,8 +40,8 @@ static int get_php_base_addr(pid_t pid, char *path, unsigned long long *raddr) {
      * address relocation and/or a feature called 'prelinking', but not sure.
      */
     char buf[128];
-    unsigned long long start_addr;
-    unsigned long long virt_addr;
+    uint64_t start_addr;
+    uint64_t virt_addr;
     char *cmd_fmt = "grep ' %s$' /proc/%d/maps | head -n1";
     if (popen_read_line(buf, sizeof(buf), cmd_fmt, path, (int)pid) != 0) {
         fprintf(stderr, "get_php_base_addr: Failed to get start_addr\n");
@@ -58,7 +58,7 @@ static int get_php_base_addr(pid_t pid, char *path, unsigned long long *raddr) {
     return 0;
 }
 
-static int get_symbol_offset(char *path, const char *symbol, unsigned long long *raddr) {
+static int get_symbol_offset(char *path, const char *symbol, uint64_t *raddr) {
     char buf[128];
     char *cmd_fmt = "readelf -s %s | grep ' %s$' | awk 'NR==1{print $2}'";
     if (popen_read_line(buf, sizeof(buf), cmd_fmt, path, symbol) != 0) {

--- a/pgrep.c
+++ b/pgrep.c
@@ -109,7 +109,7 @@ static void pgrep_for_pids() {
         pclose(pcmd);
         if (found > 0) pthread_cond_broadcast(&can_consume);
         pthread_mutex_unlock(&mutex);
-        if (found < 1) sleep(2);
+        if (found < 1) sleep(2); // TODO select/cond_wait instead of blind sleep
     }
     free(pgrep_cmd);
 }

--- a/php_structs_70.h
+++ b/php_structs_70.h
@@ -11,6 +11,10 @@ typedef struct _zend_string_70           zend_string_70;
 typedef struct _zend_op_70               zend_op_70;
 typedef struct _sapi_globals_struct_70   sapi_globals_struct_70;
 typedef struct _sapi_request_info_70     sapi_request_info_70;
+typedef struct _php_core_globals_70      php_core_globals_70;
+typedef struct _zend_array_70            zend_array_70;
+typedef struct _zval_70                  zval_70;
+typedef struct _Bucket_70                Bucket_70;
 
 // Assumes 8-byte pointers
 
@@ -50,7 +54,7 @@ struct __attribute__((__packed__)) _zend_class_entry_70 {
 struct __attribute__((__packed__)) _zend_string_70 {
     uint8_t pad0[16];                           // 0        +16
     size_t len;                                 // 16       +8
-    char *val;                                  // 24       +8
+    char val[1];                                // 24       +8
 };
 
 struct __attribute__((__packed__)) _zend_op_70 {
@@ -72,6 +76,43 @@ struct __attribute__((__packed__)) _sapi_globals_struct_70 {
     sapi_request_info_70 request_info;          // 8        +48
     uint8_t pad1[384];                          // 56       +384
     double global_request_time;                 // 440      +8
+};
+
+struct __attribute__((__packed__)) _zval_70 {
+    union {
+        int64_t lval;
+        double dval;
+        zend_string_70 *str;
+        zend_array_70 *arr;
+        // @todo support more zval types
+    } value;                                    // 0        +8
+    union {
+        struct {
+            // if big endian gets supported, this order will need to change
+            unsigned char type;                 // 8        +1
+        } v;
+    } u1;
+    uint8_t pad0[3];                            // 9        +3
+    uint32_t u2;                                // 12       +4
+};
+
+struct __attribute__((__packed__)) _php_core_globals_70 {
+    uint8_t pad0[368];                          // 0        +368
+    zval_70 http_globals[6];                    // 368      +48
+};
+
+struct __attribute__((__packed__)) _Bucket_70 {
+    zval_70 val;                               // 0        +16
+    uint64_t h;                                // 16       +8
+    zend_string_70 *key;                       // 24       +32
+};
+
+struct __attribute__((__packed__)) _zend_array_70 {
+    uint8_t pad0[16];                           // 0        +16
+    Bucket_70 *arData;                          // 16       +8
+    uint32_t nNumUsed;                          // 24       +4
+    uint32_t nNumOfElements;                    // 28       +4
+    uint32_t nTableSize;                        // 32       +4
 };
 
 #endif

--- a/php_structs_71.h
+++ b/php_structs_71.h
@@ -11,6 +11,10 @@ typedef struct _zend_string_71           zend_string_71;
 typedef struct _zend_op_71               zend_op_71;
 typedef struct _sapi_globals_struct_71   sapi_globals_struct_71;
 typedef struct _sapi_request_info_71     sapi_request_info_71;
+typedef struct _php_core_globals_71      php_core_globals_71;
+typedef struct _zend_array_71            zend_array_71;
+typedef struct _zval_71                  zval_71;
+typedef struct _Bucket_71                Bucket_71;
 
 // Assumes 8-byte pointers
 
@@ -50,7 +54,7 @@ struct __attribute__((__packed__)) _zend_class_entry_71 {
 struct __attribute__((__packed__)) _zend_string_71 {
     uint8_t pad0[16];                           // 0        +16
     size_t len;                                 // 16       +8
-    char *val;                                  // 24       +8
+    char val[1];                                // 24       +8
 };
 
 struct __attribute__((__packed__)) _zend_op_71 {
@@ -72,6 +76,43 @@ struct __attribute__((__packed__)) _sapi_globals_struct_71 {
     sapi_request_info_71 request_info;          // 8        +48
     uint8_t pad1[384];                          // 56       +384
     double global_request_time;                 // 440      +8
+};
+
+struct __attribute__((__packed__)) _zval_71 {
+    union {
+        int64_t lval;
+        double dval;
+        zend_string_71 *str;
+        zend_array_71 *arr;
+        // @todo support more zval types
+    } value;                                    // 0        +8
+    union {
+        struct {
+            // if big endian gets supported, this order will need to change
+            unsigned char type;                 // 8        +1
+        } v;
+    } u1;
+    uint8_t pad0[3];                            // 9        +3
+    uint32_t u2;                                // 12       +4
+};
+
+struct __attribute__((__packed__)) _php_core_globals_71 {
+    uint8_t pad0[368];                          // 0        +368
+    zval_71 http_globals[6];                    // 368      +48
+};
+
+struct __attribute__((__packed__)) _Bucket_71 {
+    zval_71 val;                               // 0        +16
+    uint64_t h;                                // 16       +8
+    zend_string_71 *key;                       // 24       +32
+};
+
+struct __attribute__((__packed__)) _zend_array_71 {
+    uint8_t pad0[16];                           // 0        +16
+    Bucket_71 *arData;                          // 16       +8
+    uint32_t nNumUsed;                          // 24       +4
+    uint32_t nNumOfElements;                    // 28       +4
+    uint32_t nTableSize;                        // 32       +4
 };
 
 #endif

--- a/php_structs_72.h
+++ b/php_structs_72.h
@@ -11,6 +11,10 @@ typedef struct _zend_string_72           zend_string_72;
 typedef struct _zend_op_72               zend_op_72;
 typedef struct _sapi_globals_struct_72   sapi_globals_struct_72;
 typedef struct _sapi_request_info_72     sapi_request_info_72;
+typedef struct _php_core_globals_72      php_core_globals_72;
+typedef struct _zend_array_72            zend_array_72;
+typedef struct _zval_72                  zval_72;
+typedef struct _Bucket_72                Bucket_72;
 
 // Assumes 8-byte pointers
 
@@ -50,7 +54,7 @@ struct __attribute__((__packed__)) _zend_class_entry_72 {
 struct __attribute__((__packed__)) _zend_string_72 {
     uint8_t pad0[16];                           // 0        +16
     size_t len;                                 // 16       +8
-    char *val;                                  // 24       +8
+    char val[1];                                // 24       +8
 };
 
 struct __attribute__((__packed__)) _zend_op_72 {
@@ -72,6 +76,43 @@ struct __attribute__((__packed__)) _sapi_globals_struct_72 {
     sapi_request_info_72 request_info;          // 8        +48
     uint8_t pad1[384];                          // 56       +384
     double global_request_time;                 // 440      +8
+};
+
+struct __attribute__((__packed__)) _zval_72 {
+    union {
+        int64_t lval;
+        double dval;
+        zend_string_72 *str;
+        zend_array_72 *arr;
+        // @todo support more zval types
+    } value;                                    // 0        +8
+    union {
+        struct {
+            // if big endian gets supported, this order will need to change
+            unsigned char type;                 // 8        +1
+        } v;
+    } u1;
+    uint8_t pad0[3];                            // 9        +3
+    uint32_t u2;                                // 12       +4
+};
+
+struct __attribute__((__packed__)) _php_core_globals_72 {
+    uint8_t pad0[368];                          // 0        +368
+    zval_72 http_globals[6];                    // 368      +48
+};
+
+struct __attribute__((__packed__)) _Bucket_72 {
+    zval_72 val;                               // 0        +16
+    uint64_t h;                                // 16       +8
+    zend_string_72 *key;                       // 24       +32
+};
+
+struct __attribute__((__packed__)) _zend_array_72 {
+    uint8_t pad0[16];                           // 0        +16
+    Bucket_72 *arData;                          // 16       +8
+    uint32_t nNumUsed;                          // 24       +4
+    uint32_t nNumOfElements;                    // 28       +4
+    uint32_t nTableSize;                        // 32       +4
 };
 
 #endif

--- a/php_structs_73.h
+++ b/php_structs_73.h
@@ -11,6 +11,10 @@ typedef struct _zend_string_73           zend_string_73;
 typedef struct _zend_op_73               zend_op_73;
 typedef struct _sapi_globals_struct_73   sapi_globals_struct_73;
 typedef struct _sapi_request_info_73     sapi_request_info_73;
+typedef struct _php_core_globals_73      php_core_globals_73;
+typedef struct _zend_array_73            zend_array_73;
+typedef struct _zval_73                  zval_73;
+typedef struct _Bucket_73                Bucket_73;
 
 // Assumes 8-byte pointers
 
@@ -50,7 +54,7 @@ struct __attribute__((__packed__)) _zend_class_entry_73 {
 struct __attribute__((__packed__)) _zend_string_73 {
     uint8_t pad0[16];                           // 0        +16
     size_t len;                                 // 16       +8
-    char *val;                                  // 24       +8
+    char val[1];                                // 24       +8
 };
 
 struct __attribute__((__packed__)) _zend_op_73 {
@@ -72,6 +76,43 @@ struct __attribute__((__packed__)) _sapi_globals_struct_73 {
     sapi_request_info_73 request_info;          // 8        +48
     uint8_t pad1[384];                          // 56       +384
     double global_request_time;                 // 440      +8
+};
+
+struct __attribute__((__packed__)) _zval_73 {
+    union {
+        int64_t lval;
+        double dval;
+        zend_string_73 *str;
+        zend_array_73 *arr;
+        // @todo support more zval types
+    } value;                                    // 0        +8
+    union {
+        struct {
+            // if big endian gets supported, this order will need to change
+            unsigned char type;                 // 8        +1
+        } v;
+    } u1;
+    uint8_t pad0[3];                            // 9        +3
+    uint32_t u2;                                // 12       +4
+};
+
+struct __attribute__((__packed__)) _php_core_globals_73 {
+    uint8_t pad0[368];                          // 0        +368
+    zval_73 http_globals[6];                    // 368      +48
+};
+
+struct __attribute__((__packed__)) _Bucket_73 {
+    zval_73 val;                               // 0        +16
+    uint64_t h;                                // 16       +8
+    zend_string_73 *key;                       // 24       +32
+};
+
+struct __attribute__((__packed__)) _zend_array_73 {
+    uint8_t pad0[16];                           // 0        +16
+    Bucket_73 *arData;                          // 16       +8
+    uint32_t nNumUsed;                          // 24       +4
+    uint32_t nNumOfElements;                    // 28       +4
+    uint32_t nTableSize;                        // 32       +4
 };
 
 #endif

--- a/phpspy_trace.c
+++ b/phpspy_trace.c
@@ -1,10 +1,19 @@
 #ifdef USE_ZEND
-#ifdef snprintf
-#undef snprintf
-#endif
+    #ifdef snprintf
+        #undef snprintf
+    #endif
 #endif
 
-static int dump_trace(pid_t pid, FILE *fout, unsigned long long executor_globals_addr, unsigned long long sapi_globals_addr) {
+#define try_copy_proc_mem(__what, __raddr, __laddr, __size) do {          \
+    if ((rv = copy_proc_mem(pid, (__raddr), (__laddr), (__size))) != 0) { \
+        fprintf(stderr, "dump_trace: Failed to copy %s\n", (__what));     \
+        if (wrote_trace) printf("%s", opt_trace_delim);                   \
+        return rv;                                                        \
+    }                                                                     \
+} while(0)
+
+static int dump_trace(pid_t pid, FILE *fout, uint64_t executor_globals_addr, uint64_t sapi_globals_addr, uint64_t core_globals_addr) {
+    // TODO replace params with struct ptr
     char func[STR_LEN+1];
     char file[STR_LEN+1];
     char class[STR_LEN+1];
@@ -27,22 +36,16 @@ static int dump_trace(pid_t pid, FILE *fout, unsigned long long executor_globals
     zend_function zfunc;
     zend_string zstring;
     sapi_globals_struct sapi_globals;
+    php_core_globals core_globals;
 
     depth = 0;
     wrote_trace = 0;
-
-    #define try_copy_proc_mem(__what, __raddr, __laddr, __size) do {          \
-        if ((rv = copy_proc_mem(pid, (__raddr), (__laddr), (__size))) != 0) { \
-            fprintf(stderr, "dump_trace: Failed to copy %s\n", (__what));     \
-            if (wrote_trace) printf("%s", opt_trace_delim);                   \
-            return rv;                                                        \
-        }                                                                     \
-    } while(0)
 
     executor_globals.current_execute_data = NULL;
     try_copy_proc_mem("executor_globals", (void*)executor_globals_addr, &executor_globals, sizeof(executor_globals));
     remote_execute_data = executor_globals.current_execute_data;
 
+    // TODO reduce number of copy calls
     while (remote_execute_data && depth != opt_max_stack_depth) {
         memset(&execute_data, 0, sizeof(execute_data));
         memset(&zfunc, 0, sizeof(zfunc));
@@ -91,7 +94,14 @@ static int dump_trace(pid_t pid, FILE *fout, unsigned long long executor_globals
         depth += 1;
     }
     if (wrote_trace) {
+        if (0) {
+            // TODO add support for `phpspy --spy '$varname|func /path/to.php:123'`
+            try_copy_proc_mem("core_globals", (void*)core_globals_addr, &core_globals, sizeof(core_globals));
+            print_array_recursive(pid, fout, core_globals.http_globals[3].value.arr);
+        }
+
         if (opt_capture_req) {
+            // TODO review opt_capture_req*
             try_copy_proc_mem("sapi_globals", (void*)sapi_globals_addr, &sapi_globals, sizeof(sapi_globals));
             #define try_copy_sapi_global_field(__field, __local) do {                                       \
                 if ((opt_capture_req_ ## __local) && sapi_globals.request_info.__field) {                   \
@@ -108,10 +118,83 @@ static int dump_trace(pid_t pid, FILE *fout, unsigned long long executor_globals
             #undef try_copy_sapi_global_field
             fprintf(fout, "# %f %s %s %s %s%s", sapi_globals.global_request_time, uri, qstring, path, cookie, opt_trace_delim);
         } else {
+            // TODO review output format(s)
             fprintf(fout, "# - - - - -%s", opt_trace_delim);
         }
     }
-
-    #undef try_copy_proc_mem
     return 0;
 }
+
+static int print_array_recursive(pid_t pid, FILE *fout, zend_array *array_ptr) {
+    #ifndef USE_ZEND
+        #define IS_UNDEF     0
+        #define IS_NULL      1
+        #define IS_FALSE     2
+        #define IS_TRUE      3
+        #define IS_LONG      4
+        #define IS_DOUBLE    5
+        #define IS_STRING    6
+        #define IS_ARRAY     7
+        #define IS_OBJECT    8
+        #define IS_RESOURCE  9
+        #define IS_REFERENCE 10
+    #endif
+    char *tmp;
+    int wrote_trace, rv;
+    wrote_trace = 1;
+    zend_array array; // TODO c90
+    try_copy_proc_mem("array", (void*) array_ptr , &array, sizeof(array));
+    size_t length;
+    length = array.nNumOfElements;
+    Bucket *buckets;
+    buckets = (Bucket*) malloc(sizeof(Bucket) * length);
+    try_copy_proc_mem("buckets", (void*) array.arData, buckets, sizeof(Bucket) * length);
+    unsigned int i;
+    for (i = 0; i < length; i++) {
+        // if it is a non-associative array, don't attempt to print the key
+        if (buckets[i].key != 0) {
+            copy_zend_string(pid, buckets[i].key, &tmp);
+            fprintf(fout, "%s : ", tmp);
+        }
+
+        int type = (int) buckets[i].val.u1.v.type;
+        switch (type) {
+            case IS_LONG: {
+                fprintf(fout, "%ld\n", buckets[i].val.value.lval);
+                break;
+            }
+            case IS_DOUBLE: {
+                fprintf(fout, "%lf\n", buckets[i].val.value.dval);
+                break;
+            }
+            case IS_STRING: {
+                copy_zend_string(pid, buckets[i].val.value.str, &tmp);
+                fprintf(fout, "\"%s\"\n", tmp);
+                break;
+            }
+            case IS_ARRAY: {
+                print_array_recursive(pid, fout, buckets[i].val.value.arr);
+                break;
+            }
+            default:  fprintf(fout, "value not supported, found type: %d\n", type); break;
+        }
+    }
+    free(buckets);
+    return 0;
+}
+
+static int copy_zend_string(pid_t pid, zend_string *string_ptr, char **retval) {
+    // @todo remove
+    int wrote_trace, rv;
+    wrote_trace = 1;
+    // end @todo
+    zend_string partial_string;
+    try_copy_proc_mem("string metadata", (void*) string_ptr, &partial_string, sizeof(partial_string));
+    zend_string *full_string;
+    full_string = malloc(sizeof(partial_string) + partial_string.len);
+    try_copy_proc_mem("full string", (void*) string_ptr, full_string, sizeof(partial_string) + partial_string.len);
+    *retval = (*full_string).val;
+    return 0;
+}
+
+#undef try_copy_proc_mem

--- a/phpspy_trace_tpl.c
+++ b/phpspy_trace_tpl.c
@@ -1,6 +1,10 @@
 #define concat1(a, b)         a ## b
 #define concat2(a, b)         concat1(a, b)
+#define Bucket                concat2(Bucket_, phpv)
 #define dump_trace            concat2(dump_trace_, phpv)
+#define print_array_recursive concat2(print_array_recursive_, phpv)
+#define copy_zend_string      concat2(copy_zend_string_, phpv)
+#define zend_array            concat2(zend_array_, phpv)
 #define zend_executor_globals concat2(zend_executor_globals_, phpv)
 #define zend_execute_data     concat2(zend_execute_data_, phpv)
 #define zend_function         concat2(zend_function_, phpv)
@@ -9,15 +13,23 @@
 #define zend_op               concat2(zend_op_, phpv)
 #define sapi_globals_struct   concat2(sapi_globals_struct_, phpv)
 #define sapi_request_info     concat2(sapi_request_info_, phpv)
+#define php_core_globals      concat2(php_core_globals_, phpv)
+#define zval                  concat2(zval_, phpv)
 #include "phpspy_trace.c"
+#undef Bucket
 #undef dump_trace
+#undef print_array_recursive
+#undef copy_zend_string
+#undef zend_array
 #undef zend_executor_globals
 #undef zend_execute_data
 #undef zend_function
 #undef zend_class_entry
 #undef zend_string
 #undef zend_op
+#undef zval
 #undef sapi_globals_struct
 #undef sapi_request_info
+#undef php_core_globals
 #undef concat1
 #undef concat2

--- a/struct_dump.gdb
+++ b/struct_dump.gdb
@@ -33,4 +33,26 @@ printf "sapi_globals_struct=%lu\n", sizeof(sapi_globals_struct)
 printf "  .request_info +%lu\n", offsetof(sapi_globals_struct, request_info)
 printf "  .global_request_time +%lu\n", offsetof(sapi_globals_struct, global_request_time)
 printf "\n"
+printf "php_core_globals=%lu\n", sizeof(php_core_globals)
+printf "  .http_globals +%lu\n", offsetof(php_core_globals, http_globals)
+printf "\n"
+printf "zval=%lu\n", sizeof(zval)
+printf "  .value +%lu\n", offsetof(zval, value)
+printf "  .u1 +%lu\n", offsetof(zval, u1)
+printf "\n"
+printf "zend_value=%lu\n", sizeof(zend_value)
+printf "  .str +%lu\n", offsetof(zend_value, str)
+printf "  .arr +%lu\n", offsetof(zend_value, arr)
+printf "\n"
+printf "zend_array=%lu\n", sizeof(zend_array)
+printf "  .arData +%lu\n", offsetof(zend_array, arData)
+printf "  .nNumUsed +%lu\n", offsetof(zend_array, nNumUsed)
+printf "  .nNumOfElements +%lu\n", offsetof(zend_array, nNumOfElements)
+printf "  .nTableSize +%lu\n", offsetof(zend_array, nTableSize)
+printf "\n"
+printf "Bucket=%lu\n", sizeof(Bucket)
+printf "  .val +%lu\n", offsetof(Bucket, val)
+printf "  .h +%lu\n", offsetof(Bucket, h)
+printf "  .key +%lu\n", offsetof(Bucket,key)
+printf "\n"
 printf "\n"

--- a/struct_dump.sh
+++ b/struct_dump.sh
@@ -3,6 +3,7 @@ this_dir=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null && pwd)
 phpsrc_dir=~/php-src
 
 pushd $phpsrc_dir
+git fetch --tags
 for phpv in php-7.0.29 php-7.1.21 php-7.2.9 php-7.3.0beta3; do
     git reset --hard HEAD \
         && git clean -fdx \

--- a/top.c
+++ b/top.c
@@ -20,11 +20,13 @@ extern int done;
 extern pid_t opt_pid;
 extern char *opt_pgrep_args;
 
+// TODO common header
 #define PHPSPY_MAX(a, b) ((a) > (b) ? (a) : (b))
 #define FUNC_SIZE 256
 #define BUF_SIZE 512
 
 struct func_t {
+    // TODO rename struct?
     char func[FUNC_SIZE];
     unsigned long long count_excl;
     unsigned long long count_incl;
@@ -73,6 +75,7 @@ int main_top(int argc, char **argv) {
         return 1;
     }
 
+    // TODO refactor this function
     filter_child_args(argc, argv);
     snprintf(phpspy_args, BUF_SIZE, "phpspy ");
     for (i = 1; i < argc; i++) {
@@ -91,7 +94,7 @@ int main_top(int argc, char **argv) {
     last_display.tv_sec = 0;
     last_display.tv_nsec = 0;
 
-    tb_init();
+    tb_init(); // TODO support for ncurses for portability sake?
     while (!done) {
         clock_gettime(CLOCK_MONOTONIC, &ts);
         if (last_display.tv_sec == 0 || ts.tv_sec - last_display.tv_sec >= 1) {
@@ -211,6 +214,7 @@ static void read_child_out(int fd) {
 }
 
 static void read_child_err(int fd) {
+    // TODO DRY with read_child_out
     char buf[BUF_SIZE];
     char *nl;
     size_t buf_pos;
@@ -271,7 +275,7 @@ static void handle_event(struct tb_event *event) {
     } else if (event->ch == 'q') {
         done = 1;
     } else if (event->ch == 'c') {
-        // todo
+        // TODO top mode handle_event
     }
 }
 


### PR DESCRIPTION
- add print_array_recursive method for recursively printing zend_array/HashTable types
- fixup struct_dump script to pull tags
closes #12 


example output:
```
GOPATH : "/home/mstarr/development/go"
PHP_LOG : "/var/log/httpd/php.log"
PERL_MM_OPT : "INSTALL_BASE=/home/mstarr/perl5"
_fzf_orig_completion_git : "complete -o default -o nospace -F %s git #_git"
_ : "./phpspy"
PHP_SELF : "-"
SCRIPT_NAME : "-"
SCRIPT_FILENAME : ""
PATH_TRANSLATED : ""
DOCUMENT_ROOT : ""
REQUEST_TIME_FLOAT : 4744235819330993152.000000
REQUEST_TIME : 1537564119
argv : "-"
argc : 1
```