### PR TITLE
fix libdw usage in exec mode via ptrace

### DIFF
--- a/phpspy.c
+++ b/phpspy.c
@@ -266,6 +266,7 @@ static int main_fork(int argc, char **argv) {
     if (fork_pid == 0) {
         redirect_child_stdio(STDOUT_FILENO, opt_path_child_out);
         redirect_child_stdio(STDERR_FILENO, opt_path_child_err);
+        ptrace(PTRACE_TRACEME, 0, NULL, NULL);
         execvp(argv[optind], argv + optind);
         perror("execvp");
         exit(1);
@@ -273,6 +274,9 @@ static int main_fork(int argc, char **argv) {
         perror("fork");
         exit(1);
     }
+    wait(NULL);
+    ptrace(PTRACE_EVENT_EXEC, fork_pid, NULL, NULL);
+    ptrace(PTRACE_CONT, fork_pid, NULL, NULL);
     rv = main_pid(fork_pid);
     waitpid(fork_pid, NULL, 0);
     return rv;


### PR DESCRIPTION
when using phpspy with the `-- <cmd>` option the parent process attempts to find the `executor_globals` symbol in the child process before the child process can call `execvp`. using `ptrace` can allow the parent process to be notified when the `execvp` in the child happens

if this proves to be an acceptable approach we can probably fix the pgrep mode with a similar fix

other things in commit:
- make libdw build c90 compliant
- add better error reporting after dwfl_linux_proc_report to expose syscall errors
```
[phpspy (mstarr/fix-libdw-exec) x]> make phpspy_libdw
cc -std=c90 -Wall -Wextra -pedantic -g -Ofast -pthread  -I.  -DUSE_TERMBOX=1 -DUSE_LIBDW=1 phpspy.c pgrep.c top.c addr_libdw.c addr_readelf.c -o phpspy   -ltermbox -ldw
[phpspy (mstarr/fix-libdw-exec) x]> ./phpspy -H 100 -p 20188
get_symbol_addr: Error reading from /proc. Details: Permission denied
```