### PR TITLE
 make libdwfl version of `get_symbol_addr` thread-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ phpspy_objdump: phpspy
 
 phpspy: $(wildcard *.c *.h)
 	@$(check)
-	$(CC) $(phpspy_cflags) $(phpspy_includes) $(phpspy_defines) $(phpspy_sources) -static -o phpspy $(phpspy_ldflags) $(phpspy_libs)
+	$(CC) $(phpspy_cflags) $(phpspy_includes) $(phpspy_defines) $(phpspy_sources) -o phpspy $(phpspy_ldflags) $(phpspy_libs)
 
 install: phpspy
 	install -D -v -m 755 phpspy $(DESTDIR)$(prefix)/bin/phpspy


### PR DESCRIPTION
previously in the pgrep mode all threads shared a variable that stored the string of the symbol we are looking for with libdwfl. this caused the variable to be `NULL` at certain points which caused a segfault in the `strcmp` call. this pull request cleans up that shared state and provides a pattern for passing more things into the `dwarf_module_callback` if necessary.

i also removed the `-static` flag from the libdw build because i was getting 
```
/usr/bin/ld: cannot find -ldl
/usr/bin/ld: cannot find -lz
/usr/bin/ld: cannot find -llzma
/usr/bin/ld: cannot find -lbz2
/usr/bin/ld: cannot find -lpthread
/usr/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
```

i ran this patch with `sudo  ./phpspy -V73 -r qcup -P '-x php'` and `make test` in php-src as described in #27 and didn't observe any segfaults. `valgrind -v` also didn't report any bad memory access patterns after the patch was in place