### PR TITLE
add cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+
+SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Default Build Type")
+
+PROJECT (phpspy)
+
+ADD_CUSTOM_TARGET(submodules
+                  COMMAND git submodule update --init --remote --recursive)
+
+ADD_CUSTOM_TARGET(libtermbox 
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf configure --prefix=${PROJECT_BUILD_DIR}
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf --targets=termbox_static
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/vendor/termbox
+                  DEPENDS submodules)
+
+INCLUDE_DIRECTORIES(.)
+INCLUDE_DIRECTORIES(vendor)
+INCLUDE_DIRECTORIES(vendor/termbox/src)
+
+ADD_EXECUTABLE (phpspy phpspy.c pgrep.c top.c addr_objdump.c event_fout.c)
+ADD_DEPENDENCIES (phpspy libtermbox)
+
+TARGET_LINK_LIBRARIES (phpspy pthread ${PROJECT_SOURCE_DIR}/vendor/termbox/build/src/libtermbox.a)
+
+INSTALL (TARGETS phpspy
+        RUNTIME DESTINATION bin)
+
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/phpspy.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_70.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_71.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_72.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_73.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_74.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/vendor/uthash.h
+        DESTINATION include/phpspy)
+        
+SET_TARGET_PROPERTIES(phpspy PROPERTIES 
+    COMPILE_FLAGS "-std=c99 -Wall -Werror"
+)
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ All with no changes to your application and minimal overhead.
     $ make phpspy_dynamic    # Dynamically link dependencies
     $ # or
     $ USE_ZEND=1 make ...    # Use Zend structs instead of built-in structs (requires php-dev or php-devel)
+    
+### CMake Build
+
+The CMake will update submodules and create a build of phpspy statically linked to libtermbox:
+
+    $ mkdir build
+    $ cd build
+    $ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+    $ make -j4 install
+    
+CMake Options:
+
+  * `CMAKE_BUILD_TYPE` may be `Release` or `Debug`
+  * `CMAKE_INSTALL_PREFIX` will set install prefix
 
 ### Usage
     $ ./phpspy -h


### PR DESCRIPTION
initial cmake build, and some readme ...

The custom target for submodules is a bit strange for a cmake build, but tries to immitate (somewhat) the original Makefile ...

It might be better to not have that as a target, and just include in instructions that you should update submodules, or there might be a better way to setup the custom target ... I couldn't find one. You may execute the process as part of configuring the build, and then make clean && make would not invoke the submodules target every time, but it seemed somewhat simpler to do it this way so install is "make -jX install".