### PR TITLE
[WIP] Module Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+
+SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Default Build Type")
+
+PROJECT (phpspy)
+
+ADD_CUSTOM_TARGET(submodules
+                  COMMAND git submodule update --init --remote --recursive)
+
+ADD_CUSTOM_TARGET(libtermbox 
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf configure --prefix=${PROJECT_BUILD_DIR}
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf --targets=termbox_static
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/vendor/termbox
+                  DEPENDS submodules)
+
+INCLUDE_DIRECTORIES(.)
+INCLUDE_DIRECTORIES(vendor)
+INCLUDE_DIRECTORIES(vendor/termbox/src)
+
+ADD_EXECUTABLE (phpspy phpspy.c pgrep.c top.c addr_objdump.c event_fout.c)
+ADD_DEPENDENCIES (phpspy libtermbox)
+
+TARGET_LINK_LIBRARIES (phpspy pthread ${PROJECT_SOURCE_DIR}/vendor/termbox/build/src/libtermbox.a)
+
+INSTALL (TARGETS phpspy
+        RUNTIME DESTINATION bin)
+
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/phpspy.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_70.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_71.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_72.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_73.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/php_structs_74.h
+        DESTINATION include/phpspy)
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/vendor/uthash.h
+        DESTINATION include/phpspy)
+        
+SET_TARGET_PROPERTIES(phpspy PROPERTIES 
+    COMPILE_FLAGS "-std=c99 -Wall -Werror"
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+
+SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Default Build Type")
+
+PROJECT (phpspy)
+
+ADD_CUSTOM_TARGET(submodules
+                  COMMAND git submodule update --init --remote --recursive)
+
+ADD_CUSTOM_TARGET(libtermbox 
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf configure --prefix=${PROJECT_BUILD_DIR}
+                  COMMAND ${PROJECT_SOURCE_DIR}/vendor/termbox/waf --targets=termbox_static
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/vendor/termbox
+                  DEPENDS submodules)
+
+INCLUDE_DIRECTORIES(.)
+INCLUDE_DIRECTORIES(vendor)
+INCLUDE_DIRECTORIES(vendor/termbox/src)
+
+ADD_EXECUTABLE (phpspy phpspy.c pgrep.c top.c addr_objdump.c event_fout.c)
+ADD_DEPENDENCIES (phpspy libtermbox)
+
+TARGET_LINK_LIBRARIES (phpspy pthread ${PROJECT_SOURCE_DIR}/vendor/termbox/build/src/libtermbox.a)
+
+INSTALL (TARGETS phpspy
+        RUNTIME DESTINATION bin)
+
+INSTALL (FILES ${PROJECT_SOURCE_DIR}/phpspy.h
+        DESTINATION include/phpspy)
+
+SET_TARGET_PROPERTIES(phpspy PROPERTIES 
+    COMPILE_FLAGS "-std=c99 -Wall -Werror"
+)
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ All with no changes to your application and minimal overhead.
     $ make phpspy_dynamic    # Dynamically link dependencies
     $ # or
     $ USE_ZEND=1 make ...    # Use Zend structs instead of built-in structs (requires php-dev or php-devel)
+    
+### CMake Build
+
+The CMake will update submodules and create a build of phpspy statically linked to libtermbox:
+
+    $ mkdir build
+    $ cd build
+    $ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+    $ make -j4 install
+    
+CMake Options:
+
+  * `CMAKE_BUILD_TYPE` may be `Release` or `Debug`
+  * `CMAKE_INSTALL_PREFIX` will set install prefix
 
 ### Usage
     $ ./phpspy -h

--- a/module.c
+++ b/module.c
@@ -1,0 +1,20 @@
+/*
+    Requires CMake build of phpspy (for headers)
+    
+    compile: gcc -shared -fPIC -Wl,-init,phpspy_module_init ../module.c -I/opt/include/phpspy -o module.so
+    run    : sudo LD_PRELOAD=./module.so /opt/bin/phpspy -p PID
+    
+    TODO:
+        make cmake build for module
+*/
+
+#include <phpspy.h>
+
+int phpspy_module_handler(trace_context_t *context, int type) {
+    fprintf(stderr, "event: %d\n", type);
+    return 0;
+}
+
+void phpspy_module_init() {
+    phpspy_event_handler = phpspy_module_handler;
+}

--- a/phpspy.c
+++ b/phpspy.c
@@ -1,4 +1,5 @@
-#include "phpspy.h"
+#include <phpspy.h>
+#include <termbox.h>
 
 pid_t opt_pid = -1;
 char *opt_pgrep_args = NULL;
@@ -259,7 +260,9 @@ int main_pid(pid_t pid) {
 
     memset(&context, 0, sizeof(trace_context_t));
     context.target.pid = pid;
-    context.event_handler = event_handler_fout; /* TODO set based on option */
+    context.event_handler = phpspy_event_handler ? 
+                                phpspy_event_handler : event_handler_fout;
+    
     try(rv, find_addresses(&context.target));
     try(rv, context.event_handler(&context, PHPSPY_TRACE_EVENT_INIT));
 

--- a/phpspy.h
+++ b/phpspy.h
@@ -23,7 +23,6 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
-#include <termbox.h>
 #include <regex.h>
 
 #ifdef USE_ZEND
@@ -75,6 +74,12 @@
 #define IS_OBJECT    8
 #define IS_RESOURCE  9
 #define IS_REFERENCE 10
+#endif
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+# define PHPSPY_API __attribute__ ((visibility("default")))
+#else
+# define PHPSPY_API
 #endif
 
 typedef struct varpeek_var_s {
@@ -176,5 +181,7 @@ extern int main_top(int argc, char **argv);
 extern void usage(FILE *fp, int exit_code);
 extern int get_symbol_addr(addr_memo_t *memo, pid_t pid, const char *symbol, uint64_t *raddr);
 extern int event_handler_fout(struct trace_context_s *context, int event_type);
+
+PHPSPY_API int (*phpspy_event_handler)(trace_context_t *, int);
 
 #endif

--- a/top.c
+++ b/top.c
@@ -1,4 +1,5 @@
-#include "phpspy.h"
+#include <phpspy.h>
+#include <termbox.h>
 
 #define FUNC_SIZE 256
 #define BUF_SIZE 512


### PR DESCRIPTION
This is a WIP for module support, and depends on CMake PR

The basic idea is that phpspy should export handler pointer, LD_PRELOAD is used to load the module and set that handler ...

TODO:

  * CMake build for module
  * Support standard makefile build ?
  * Have phpspy detect when handler is not builtin, force pid mode only ?

This is nothing like complete, but a thing to get the conversation started ...

Open questions:

  * Depend on libdl so that phpspy may load the modules (no preload)
  * Support makefiles (ewww)
  * Define module structure with individual handlers for each event, so that a module may set handlers for events it intends to process.

Implements #60 