### PR TITLE
Add Dockerfile for easier setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.3-fpm-alpine
+RUN apk add --update alpine-sdk python
+RUN git clone --recursive https://github.com/adsr/phpspy.git
+RUN cd phpspy && make

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ All with no changes to your application and minimal overhead.
     # - - - - -
     ...
 
+### Example (docker)
+    $ docker build . -t phpspy
+    $ docker run -it --cap-add SYS_PTRACE phpspy:latest ./phpspy/phpspy -V73 -r -- php -r 'sleep(1);'
+    0 sleep <internal>:-1
+    1 <main> <internal>:-1
+    ...
+
 ### Credits
 
 * phpspy is inspired by [rbspy][0].


### PR DESCRIPTION
MacOS and Windows developers are not able to build phpspy locally. See
https://github.com/adsr/phpspy/issues/49.

This commit provides an interim solution by allowing developers to run
phpspy in a container.

This `Dockerfile` will only work with PHP version 7.3.