### PR TITLE
Fix pgrep mode limit and limit-timer

### DIFF
--- a/pgrep.c
+++ b/pgrep.c
@@ -207,10 +207,12 @@ static void *run_signal_thread(void *arg) {
         tv.tv_sec = 1;
         tv.tv_usec = 0;
         rv = select(done_pipe[0]+1, &rfds, NULL, NULL, &tv);
-    } while (rv < 1);
+    } while (rv < 1 && done == 0);
 
     /* Read pipe for fun */
-    rv = read(done_pipe[0], &signum, sizeof(int));
+    if (rv) {
+      rv = read(done_pipe[0], &signum, sizeof(int));
+    }
 
     /* Set done flag; wake up all threads */
     done = 1;

--- a/phpspy.c
+++ b/phpspy.c
@@ -361,9 +361,17 @@ int main_pid(pid_t pid) {
         if (opt_pause) rv |= pause_pid(pid);                             /* maybe PTRACE_ATTACH */
         rv |= do_trace_ptr(&context);                                    /* trace */
         if (opt_pause) rv |= unpause_pid(pid);                           /* maybe PTRACE_DETACH */
-        if ((rv == 0 && ++n == opt_trace_limit) || (rv & 2) != 0) break; /* maybe apply trace limit */
+        /* maybe apply trace limit */
+        if ((rv == 0 && ++n == opt_trace_limit) || (rv & 2) != 0) {
+            done = 1;
+            break;
+        }
         clock_get(&end_time);
-        if (stop_time && clock_diff(&end_time, stop_time) >= 1) break;   /* maybe apply time limit */
+        /* maybe apply time limit */
+        if (stop_time && clock_diff(&end_time, stop_time) >= 1) {
+            done = 1;
+            break;
+        }
         calc_sleep_time(&end_time, &start_time, &sleep_time);
         nanosleep(&sleep_time, NULL);                                    /* sleep */
     }


### PR DESCRIPTION
Fixes #58

In pgrep mode, workers never exit after hitting the limit, they just exit
main_pid and then get reassigned continuously.

This patch fixes this by setting the global "done" value and adds checking
for this inside the pgrep signal handler.