### PR TITLE
Allow `--peek-global` to access `$GLOBALS` as well as modified superglobals

### DIFF
--- a/php_structs_70.h
+++ b/php_structs_70.h
@@ -22,8 +22,20 @@ typedef struct _zend_mm_heap_70          zend_mm_heap_70;
 
 /* Assumes 8-byte pointers */
                                                     /* offset   length */
+struct __attribute__((__packed__)) _zend_array_70 {
+    uint8_t                 pad0[12];               /* 0        +12 */
+    uint32_t                nTableMask;             /* 12       +4 */
+    Bucket_70               *arData;                /* 16       +8 */
+    uint32_t                nNumUsed;               /* 24       +4 */
+    uint32_t                nNumOfElements;         /* 28       +4 */
+    uint32_t                nTableSize;             /* 32       +4 */
+    uint8_t                 pad1[20];               /* 36       +20 */
+};
+
 struct __attribute__((__packed__)) _zend_executor_globals_70 {
-    uint8_t                 pad0[480];              /* 0        +480 */
+    uint8_t                 pad0[304];              /* 0        +304 */
+    zend_array_70           symbol_table;           /* 304      +56 */
+    uint8_t                 pad1[120];              /* 360      +120 */
     zend_execute_data_70    *current_execute_data;  /* 480      +8 */
 };
 
@@ -111,15 +123,6 @@ struct __attribute__((__packed__)) _zval_70 {
 struct __attribute__((__packed__)) _php_core_globals_70 {
     uint8_t                 pad0[368];              /* 0        +368 */
     zval_70                 http_globals[6];        /* 368      +48 */
-};
-
-struct __attribute__((__packed__)) _zend_array_70 {
-    uint8_t                 pad0[12];               /* 0        +12 */
-    uint32_t                nTableMask;             /* 12       +4 */
-    Bucket_70               *arData;                /* 16       +8 */
-    uint32_t                nNumUsed;               /* 24       +4 */
-    uint32_t                nNumOfElements;         /* 28       +4 */
-    uint32_t                nTableSize;             /* 32       +4 */
 };
 
 struct __attribute__((__packed__)) _Bucket_70 {

--- a/php_structs_71.h
+++ b/php_structs_71.h
@@ -22,8 +22,20 @@ typedef struct _zend_mm_heap_71          zend_mm_heap_71;
 
 /* Assumes 8-byte pointers */
                                                     /* offset   length */
+struct __attribute__((__packed__)) _zend_array_71 {
+    uint8_t                 pad0[12];               /* 0        +12 */
+    uint32_t                nTableMask;             /* 12       +4 */
+    Bucket_71               *arData;                /* 16       +8 */
+    uint32_t                nNumUsed;               /* 24       +4 */
+    uint32_t                nNumOfElements;         /* 28       +4 */
+    uint32_t                nTableSize;             /* 32       +4 */
+    uint8_t                 pad1[20];               /* 36       +20 */
+};
+
 struct __attribute__((__packed__)) _zend_executor_globals_71 {
-    uint8_t                 pad0[480];              /* 0        +480 */
+    uint8_t                 pad0[304];              /* 0        +304 */
+    zend_array_71           symbol_table;           /* 304      +56 */
+    uint8_t                 pad1[120];              /* 360      +120 */
     zend_execute_data_71    *current_execute_data;  /* 480      +8 */
 };
 
@@ -111,15 +123,6 @@ struct __attribute__((__packed__)) _zval_71 {
 struct __attribute__((__packed__)) _php_core_globals_71 {
     uint8_t                 pad0[368];              /* 0        +368 */
     zval_71                 http_globals[6];        /* 368      +48 */
-};
-
-struct __attribute__((__packed__)) _zend_array_71 {
-    uint8_t                 pad0[12];               /* 0        +12 */
-    uint32_t                nTableMask;             /* 12       +4 */
-    Bucket_71               *arData;                /* 16       +8 */
-    uint32_t                nNumUsed;               /* 24       +4 */
-    uint32_t                nNumOfElements;         /* 28       +4 */
-    uint32_t                nTableSize;             /* 32       +4 */
 };
 
 struct __attribute__((__packed__)) _Bucket_71 {

--- a/php_structs_72.h
+++ b/php_structs_72.h
@@ -22,8 +22,20 @@ typedef struct _zend_mm_heap_72          zend_mm_heap_72;
 
 /* Assumes 8-byte pointers */
                                                     /* offset   length */
+struct __attribute__((__packed__)) _zend_array_72 {
+    uint8_t                 pad0[12];               /* 0        +12 */
+    uint32_t                nTableMask;             /* 12       +4 */
+    Bucket_72               *arData;                /* 16       +8 */
+    uint32_t                nNumUsed;               /* 24       +4 */
+    uint32_t                nNumOfElements;         /* 28       +4 */
+    uint32_t                nTableSize;             /* 32       +4 */
+    uint8_t                 pad1[20];               /* 36       +20 */
+};
+
 struct __attribute__((__packed__)) _zend_executor_globals_72 {
-    uint8_t                 pad0[480];              /* 0        +480 */
+    uint8_t                 pad0[304];              /* 0        +304 */
+    zend_array_72           symbol_table;           /* 304      +56 */
+    uint8_t                 pad1[120];              /* 360      +120 */
     zend_execute_data_72    *current_execute_data;  /* 480      +8 */
 };
 
@@ -111,15 +123,6 @@ struct __attribute__((__packed__)) _zval_72 {
 struct __attribute__((__packed__)) _php_core_globals_72 {
     uint8_t                 pad0[368];              /* 0        +368 */
     zval_72                 http_globals[6];        /* 368      +48 */
-};
-
-struct __attribute__((__packed__)) _zend_array_72 {
-    uint8_t                 pad0[12];               /* 0        +12 */
-    uint32_t                nTableMask;             /* 12       +4 */
-    Bucket_72               *arData;                /* 16       +8 */
-    uint32_t                nNumUsed;               /* 24       +4 */
-    uint32_t                nNumOfElements;         /* 28       +4 */
-    uint32_t                nTableSize;             /* 32       +4 */
 };
 
 struct __attribute__((__packed__)) _Bucket_72 {

--- a/php_structs_73.h
+++ b/php_structs_73.h
@@ -22,8 +22,20 @@ typedef struct _zend_mm_heap_73          zend_mm_heap_73;
 
 /* Assumes 8-byte pointers */
                                                     /* offset   length */
+struct __attribute__((__packed__)) _zend_array_73 {
+    uint8_t                 pad0[12];               /* 0        +12 */
+    uint32_t                nTableMask;             /* 12       +4 */
+    Bucket_73               *arData;                /* 16       +8 */
+    uint32_t                nNumUsed;               /* 24       +4 */
+    uint32_t                nNumOfElements;         /* 28       +4 */
+    uint32_t                nTableSize;             /* 32       +4 */
+    uint8_t                 pad1[20];               /* 36       +20 */
+};
+
 struct __attribute__((__packed__)) _zend_executor_globals_73 {
-    uint8_t                 pad0[488];              /* 0        +488 */
+    uint8_t                 pad0[304];              /* 0        +304 */
+    zend_array_73           symbol_table;           /* 304      +56 */
+    uint8_t                 pad1[128];              /* 360      +128 */
     zend_execute_data_73    *current_execute_data;  /* 488      +8 */
 };
 
@@ -111,15 +123,6 @@ struct __attribute__((__packed__)) _zval_73 {
 struct __attribute__((__packed__)) _php_core_globals_73 {
     uint8_t                 pad0[368];              /* 0        +368 */
     zval_73                 http_globals[6];        /* 368      +48 */
-};
-
-struct __attribute__((__packed__)) _zend_array_73 {
-    uint8_t                 pad0[12];               /* 0        +12 */
-    uint32_t                nTableMask;             /* 12       +4 */
-    Bucket_73               *arData;                /* 16       +8 */
-    uint32_t                nNumUsed;               /* 24       +4 */
-    uint32_t                nNumOfElements;         /* 28       +4 */
-    uint32_t                nTableSize;             /* 32       +4 */
 };
 
 struct __attribute__((__packed__)) _Bucket_73 {

--- a/php_structs_74.h
+++ b/php_structs_74.h
@@ -22,8 +22,20 @@ typedef struct _zend_mm_heap_74          zend_mm_heap_74;
 
 /* Assumes 8-byte pointers */
                                                     /* offset   length */
+struct __attribute__((__packed__)) _zend_array_74 {
+    uint8_t                 pad0[12];               /* 0        +12 */
+    uint32_t                nTableMask;             /* 12       +4 */
+    Bucket_74               *arData;                /* 16       +8 */
+    uint32_t                nNumUsed;               /* 24       +4 */
+    uint32_t                nNumOfElements;         /* 28       +4 */
+    uint32_t                nTableSize;             /* 32       +4 */
+    uint8_t                 pad1[20];               /* 36       +20 */
+};
+
 struct __attribute__((__packed__)) _zend_executor_globals_74 {
-    uint8_t                 pad0[488];              /* 0        +488 */
+    uint8_t                 pad0[304];              /* 0        +304 */
+    zend_array_74           symbol_table;           /* 304      +56 */
+    uint8_t                 pad1[128];              /* 360      +128 */
     zend_execute_data_74    *current_execute_data;  /* 488      +8 */
 };
 
@@ -111,15 +123,6 @@ struct __attribute__((__packed__)) _zval_74 {
 struct __attribute__((__packed__)) _php_core_globals_74 {
     uint8_t                 pad0[368];              /* 0        +368 */
     zval_74                 http_globals[6];        /* 368      +48 */
-};
-
-struct __attribute__((__packed__)) _zend_array_74 {
-    uint8_t                 pad0[12];               /* 0        +12 */
-    uint32_t                nTableMask;             /* 12       +4 */
-    Bucket_74               *arData;                /* 16       +8 */
-    uint32_t                nNumUsed;               /* 24       +4 */
-    uint32_t                nNumOfElements;         /* 28       +4 */
-    uint32_t                nTableSize;             /* 32       +4 */
 };
 
 struct __attribute__((__packed__)) _Bucket_74 {

--- a/phpspy.c
+++ b/phpspy.c
@@ -31,7 +31,6 @@ int (*opt_event_handler)(struct trace_context_s *context, int event_type) = even
 int opt_continue_on_error = 0;
 int opt_fout_buffer_size = 4096;
 
-size_t zend_string_val_offset = 0;
 int done = 0;
 int (*do_trace_ptr)(trace_context_t *context) = NULL;
 varpeek_entry_t *varpeek_map = NULL;
@@ -566,13 +565,6 @@ static int find_addresses(trace_target_t *target) {
         target->basic_functions_module_addr = 0;
     }
     log_error_enabled = 1;
-
-    /* TODO probably don't need zend_string_val_offset */
-    #ifdef USE_ZEND
-    zend_string_val_offset = offsetof(zend_string, val);
-    #else
-    zend_string_val_offset = offsetof(zend_string_70, val);
-    #endif
     return PHPSPY_OK;
 }
 

--- a/phpspy.h
+++ b/phpspy.h
@@ -97,8 +97,8 @@ typedef struct varpeek_entry_s {
 
 typedef struct glopeek_entry_s {
     char key[PHPSPY_STR_SIZE];
-    int index;
-    char varname[PHPSPY_STR_SIZE];
+    char gloname[PHPSPY_STR_SIZE]; /* The name of the superglobal array */
+    char varname[PHPSPY_STR_SIZE]; /* The name of the global variable within the superglobal array */
     UT_hash_handle hh;
 } glopeek_entry_t;
 
@@ -145,7 +145,6 @@ typedef struct trace_target_s {
     pid_t pid;
     uint64_t executor_globals_addr;
     uint64_t sapi_globals_addr;
-    uint64_t core_globals_addr;
     uint64_t alloc_globals_addr;
     uint64_t basic_functions_module_addr;
 } trace_target_t;

--- a/phpspy_trace_tpl.c
+++ b/phpspy_trace_tpl.c
@@ -18,16 +18,17 @@
 #define zval                  concat2(zval_,                  phpv)
 
 #define do_trace              concat2(do_trace_,              phpv)
+#define trace_stack           concat2(trace_stack_,           phpv)
+#define trace_request_info    concat2(trace_request_info_,    phpv)
+#define trace_memory_info     concat2(trace_memory_info_,     phpv)
+#define trace_globals         concat2(trace_globals_,         phpv)
+#define trace_locals          concat2(trace_locals_,          phpv)
 #define copy_executor_globals concat2(copy_executor_globals_, phpv)
-#define copy_stack            concat2(copy_stack_,            phpv)
-#define copy_request_info     concat2(copy_request_info_,     phpv)
-#define copy_memory_info      concat2(copy_memory_info_,      phpv)
-#define copy_globals          concat2(copy_globals_,          phpv)
-#define copy_locals           concat2(copy_locals_,           phpv)
-#define copy_zstring          concat2(copy_zstring_,          phpv)
-#define copy_zval             concat2(copy_zval_,             phpv)
-#define copy_zarray           concat2(copy_zarray_,           phpv)
-#define copy_zarray_bucket    concat2(copy_zarray_bucket_,    phpv)
+#define sprint_zstring        concat2(sprint_zstring_,        phpv)
+#define sprint_zval           concat2(sprint_zval_,           phpv)
+#define sprint_zarray         concat2(sprint_zarray_,         phpv)
+#define sprint_zarray_element concat2(sprint_zarray_element_, phpv)
+#define sprint_zarray_bucket  concat2(sprint_zarray_bucket_,  phpv)
 
 #include "phpspy_trace.c"
 
@@ -51,13 +52,14 @@
 #undef zval
 
 #undef do_trace
+#undef trace_stack
+#undef trace_request_info
+#undef trace_memory_info
+#undef trace_globals
+#undef trace_locals
 #undef copy_executor_globals
-#undef copy_stack
-#undef copy_request_info
-#undef copy_memory_info
-#undef copy_globals
-#undef copy_locals
-#undef copy_zstring
-#undef copy_zval
-#undef copy_zarray
-#undef copy_zarray_bucket
+#undef sprint_zstring
+#undef sprint_zval
+#undef sprint_zarray
+#undef sprint_zarray_element
+#undef sprint_zarray_bucket

--- a/phpspy_trace_tpl.c
+++ b/phpspy_trace_tpl.c
@@ -24,10 +24,11 @@
 #define trace_globals         concat2(trace_globals_,         phpv)
 #define trace_locals          concat2(trace_locals_,          phpv)
 #define copy_executor_globals concat2(copy_executor_globals_, phpv)
+#define copy_zarray_bucket    concat2(copy_zarray_bucket_,    phpv)
 #define sprint_zstring        concat2(sprint_zstring_,        phpv)
 #define sprint_zval           concat2(sprint_zval_,           phpv)
 #define sprint_zarray         concat2(sprint_zarray_,         phpv)
-#define sprint_zarray_element concat2(sprint_zarray_element_, phpv)
+#define sprint_zarray_val     concat2(sprint_zarray_val,      phpv)
 #define sprint_zarray_bucket  concat2(sprint_zarray_bucket_,  phpv)
 
 #include "phpspy_trace.c"
@@ -58,8 +59,9 @@
 #undef trace_globals
 #undef trace_locals
 #undef copy_executor_globals
+#undef copy_zarray_bucket
 #undef sprint_zstring
 #undef sprint_zval
 #undef sprint_zarray
-#undef sprint_zarray_element
+#undef sprint_zarray_val
 #undef sprint_zarray_bucket

--- a/struct_dump.gdb
+++ b/struct_dump.gdb
@@ -8,6 +8,7 @@ end
 
 printf "zend_executor_globals\n"
 whatis zend_executor_globals
+       fieldof zend_executor_globals symbol_table
        fieldof zend_executor_globals current_execute_data
 printf "\n"
 

--- a/struct_dump.sh
+++ b/struct_dump.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 this_dir=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null && pwd)
-phpsrc_dir=~/php-src
+phpsrc_dir=$1
+
+if [ -z "$phpsrc_dir" ]; then
+    echo "Required: php-src directory"
+    exit 1
+fi
 
 pushd $phpsrc_dir
 git fetch --tags
-for phpv in php-7.0.29 php-7.1.21 php-7.2.9 php-7.3.0beta3; do
+for phpv in php-7.0.33 php-7.1.33 php-7.2.30 php-7.3.17 php-7.4.5; do
     git reset --hard HEAD \
         && git clean -fdx \
         && git checkout $phpv \

--- a/tests/test_glopeek.sh
+++ b/tests/test_glopeek.sh
@@ -2,6 +2,9 @@
 
 read -r -d '' php_src <<'EOD'
 <?php
+$GLOBALS['my_global'] = 'test_global';
+$_SERVER['FAKE_VAR'] = 121;
+$_SERVER['SCRIPT_NAME'] = 'not_real.php';
 function f() {
     $a = 42;
     sleep(1);
@@ -10,9 +13,12 @@ f();
 EOD
 php_file=$(mktemp)
 echo "$php_src" >$php_file
-phpspy_opts=(--limit=0 --peek-global "server.REQUEST_TIME" -- $PHP $php_file)
+phpspy_opts=(--limit=0 --peek-global "server.REQUEST_TIME" --peek-global "globals.my_global" --peek-global "server.FAKE_VAR" --peek-global "server.SCRIPT_NAME" -- $PHP $php_file)
 declare -A expected
-expected[glopeek        ]="^# glopeek server.REQUEST_TIME = \d+"
+expected[glopeek_server    ]="^# glopeek server.REQUEST_TIME = \d+"
+expected[glopeek_globals   ]="^# glopeek globals.my_global = test_global"
+expected[glopeek_server_new]="^# glopeek server.FAKE_VAR = 121"
+expected[glopeek_server_mod]="^# glopeek server.SCRIPT_NAME = not_real.php"
 source $TEST_SH
 rm -f $php_file
 
@@ -23,4 +29,3 @@ declare -A expected
 expected[glopeek1       ]="^# glopeek server.Ez = 1"
 expected[glopeek2       ]="^# glopeek server.FY = 2"
 source $TEST_SH
-rm -f $php_file


### PR DESCRIPTION
The existing implementation of `--peek-global` looks exclusively in the `php_core_globals` array, which holds only superglobal arrays with the values they have upon initialization. Instead, we can look in `executor_globals.symbol_table`, which holds up-to-date values of both superglobals and the `$GLOBALS` array: `$GLOBALS` elements are stored directly in the symbol table, and superglobals are storeed in sub-arrays indexed with strings such as `_SERVER`.

In addition, I've standardized naming and documentation across the functions in `phpspy_trace.c`, some of which was prompted by refactoring required for the above change.