### PR TITLE
Add shell escaping

### DIFF
--- a/addr_objdump.c
+++ b/addr_objdump.c
@@ -138,7 +138,10 @@ static int popen_read_line(char *buf, size_t buf_size, char *cmd_fmt, ...) {
     int buf_len;
     va_list cmd_args;
     va_start(cmd_args, cmd_fmt);
-    vsprintf(cmd, cmd_fmt, cmd_args);
+    if (vsnprintf(cmd, sizeof(cmd), cmd_fmt, cmd_args) >= (int)(sizeof(cmd) - 1)) {
+        log_error("vsnprintf overflow\n");
+        return 1;
+    }
     va_end(cmd_args);
     if (!(fp = popen(cmd, "r"))) {
         perror("popen");


### PR DESCRIPTION
* Not implemented for the `pgrep` command in pgrep-mode - gonna trust the user on that :)
* Not implemented for the `version_cmd` because it's not needed there (only numbers are encoded, not strings)
* Not escaping symbol names in `get_symbol_offset` because they are constants throughout the project.

I tested it with a PHP binary I put in `/tmp/php''$(echo > yyy)`. Works like a charm (and no `yyy` file created in cwd, but neither does in master).
Also tested with `/tmp/php$(echo > abc)`, no `abc` file created in cwd.
On master - both don't work & `abc` is created.

Also dropped a small commit that fixes a missing s(n)printf overflow (like https://github.com/adsr/phpspy/commit/3120b8d1bf205639970aa2de566b888aba5b6884)

Closes: #81