### PR TITLE
Check for 'libphp' as possible module name in php version autodetection for php 8 compatibility

### DIFF
--- a/addr_objdump.c
+++ b/addr_objdump.c
@@ -61,7 +61,7 @@ int get_symbol_addr(addr_memo_t *memo, pid_t pid, const char *symbol, uint64_t *
 
 static int get_php_bin_path(pid_t pid, char *path_root, char *path) {
     char buf[PHPSPY_STR_SIZE];
-    char *cmd_fmt = "awk '/libphp[78]/{print $NF; exit 0} END{exit 1}' /proc/%d/maps"
+    char *cmd_fmt = "awk '/libphp[78]?/{print $NF; exit 0} END{exit 1}' /proc/%d/maps"
         " || readlink /proc/%d/exe";
     if (popen_read_line(buf, sizeof(buf), cmd_fmt, (int)pid, (int)pid) != 0) {
         log_error("get_php_bin_path: Failed\n");

--- a/phpspy.c
+++ b/phpspy.c
@@ -749,7 +749,7 @@ static int get_php_version(trace_target_t *target) {
             version_cmd,
             sizeof(version_cmd),
             "{ echo -n /proc/%d/root/; "
-            "  awk -ve=1 '/libphp[78]/{print $NF; e=0; exit} END{exit e}' /proc/%d/maps "
+            "  awk -ve=1 '/libphp[78]?/{print $NF; e=0; exit} END{exit e}' /proc/%d/maps "
             "  || readlink /proc/%d/exe; } "
             "| { xargs stat --printf=%%n 2>/dev/null || echo /proc/%d/exe; } "
             "| xargs strings "


### PR DESCRIPTION
The Apache module for PHP 8 is named `libphp.so`
https://www.php.net/manual/en/install.unix.apache2.php

```
[jchen@web-red-wmtv ~]$ php --version
PHP 8.0.18 (cli) (built: Apr 17 2022 19:40:43) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.18, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.18, Copyright (c), by Zend Technologies
[jchen@web-red-wmtv ~]$ ls /etc/httpd/modules/libphp*
/etc/httpd/modules/libphp.so
```