### PR TITLE
Update Makefile to support git clone and release when packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ vendor/termbox2/termbox2.h:
 	if [ -d "$(CURDIR)/.git" ]; then \
 		git submodule update --init --recursive; \
 		cd vendor/termbox2 && git reset --hard; \
-    else \
-        cd vendor; \
+	else \
+		cd vendor; \
 		git clone https://github.com/termbox/termbox2.git; \
-    fi
+	fi
 
 test: phpspy $(phpspy_tests)
 	@total=0; \

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,13 @@ phpspy: $(wildcard *.c *.h) vendor/termbox2/termbox2.h
 	$(CC) $(phpspy_cflags) $(phpspy_includes) $(termbox_inlcudes) $(phpspy_defines) $(phpspy_sources) -o phpspy $(phpspy_ldflags) $(phpspy_libs)
 
 vendor/termbox2/termbox2.h:
-	git submodule update --init --recursive
-	cd vendor/termbox2 && git reset --hard
+	if [ -d "$(CURDIR)/.git" ]; then \
+		git submodule update --init --recursive; \
+		cd vendor/termbox2 && git reset --hard; \
+    else \
+        cd vendor; \
+		git clone https://github.com/termbox/termbox2.git; \
+    fi
 
 test: phpspy $(phpspy_tests)
 	@total=0; \


### PR DESCRIPTION
Certain packaging systems make use of Github releases (source tarballs)  instead of git cloning the source repo. I modified the Makefile to git clone termbox2 in the vendor directory when the phpspy directory is not a git repo.