### PR TITLE
Use grep without perl option

### DIFF
--- a/phpspy.c
+++ b/phpspy.c
@@ -779,7 +779,8 @@ static int get_php_version(trace_target_t *target) {
             "  || readlink /proc/%d/exe; } "
             "| { xargs stat --printf=%%n 2>/dev/null || echo /proc/%d/exe; } "
             "| xargs strings "
-            "| grep -Po '(?<=X-Powered-By: PHP/)\\d\\.\\d'",
+            "| grep -o 'X-Powered-By: PHP/\\d\\.\\d' "
+            "| grep -o '\\d\\.\\d' ",
             pid, libname, pid, pid, pid
         );
         if ((size_t)n >= sizeof(version_cmd) - 1) {

--- a/phpspy.c
+++ b/phpspy.c
@@ -779,8 +779,8 @@ static int get_php_version(trace_target_t *target) {
             "  || readlink /proc/%d/exe; } "
             "| { xargs stat --printf=%%n 2>/dev/null || echo /proc/%d/exe; } "
             "| xargs strings "
-            "| grep -o 'X-Powered-By: PHP/\\d\\.\\d' "
-            "| grep -o '\\d\\.\\d' ",
+            "| grep -Eo 'X-Powered-By: PHP/[0-9]+\\.[0-9]+' "
+            "| grep -Eo '[0-9]+\\.[0-9]+' ",
             pid, libname, pid, pid, pid
         );
         if ((size_t)n >= sizeof(version_cmd) - 1) {


### PR DESCRIPTION
Used `docker run --rm php php -r 'foreach (range(0,30000) as $i) {echo $i."\n"; sleep(1);}'` as a test process

Build from default dockerfile as ` docker build -t phpspy-test .`
```
➜  phpspy git:(master) docker run --pid=host --privileged --cap-add SYS_PTRACE --rm phpspy-test phpspy/phpspy --pid=2701841 
grep: unrecognized option: P
BusyBox v1.36.1 (2024-06-10 07:11:47 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...
....
        -f FILE Read pattern from file
xargs: 'strings' terminated by signal 13
get_php_version: Could not detect PHP version
```

Patched version:
```
➜  phpspy git:(master) docker run --pid=host --privileged --cap-add SYS_PTRACE --rm phpspy-patched phpspy/phpspy --pid=2701841 -l 1
0 sleep <internal>:-1
1 <main> <internal>:-1
```
