### PR TITLE
Allow using split debug symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ All with no changes to your application and minimal overhead.
                                            (default: QCUP; none)
       -m, --memory-usage                 Capture peak and current memory usage
                                            with each trace (requires target PHP
-                                           process to have debug symbols)
+                                           process to have debug symbols either built-in or as a separate file)
       -o, --output=<path>                Write phpspy output to `path`
                                            (default: -; -=stdout)
       -O, --child-stdout=<path>          Write child stdout to `path`

--- a/phpspy.c
+++ b/phpspy.c
@@ -134,7 +134,7 @@ void usage(FILE *fp, int exit_code) {
     fprintf(fp, "                                       (default: QCUP; none)\n");
     fprintf(fp, "  -m, --memory-usage                 Capture peak and current memory usage\n");
     fprintf(fp, "                                       with each trace (requires target PHP\n");
-    fprintf(fp, "                                       process to have debug symbols)\n");
+    fprintf(fp, "                                       process to have debug symbols either built-in or as a separate file)\n");
     fprintf(fp, "  -o, --output=<path>                Write phpspy output to `path`\n");
     fprintf(fp, "                                       (default: %s; -=stdout)\n", opt_path_output);
     fprintf(fp, "  -O, --child-stdout=<path>          Write child stdout to `path`\n");

--- a/phpspy.h
+++ b/phpspy.h
@@ -182,6 +182,7 @@ typedef struct trace_context_s {
 } trace_context_t;
 
 typedef struct addr_memo_s {
+    char php_symbol_path[PHPSPY_STR_SIZE];
     char php_bin_path[PHPSPY_STR_SIZE];
     char php_bin_path_root[PHPSPY_STR_SIZE];
     uint64_t php_base_addr;


### PR DESCRIPTION
[Further](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html) improvements could be made to also add support for debug links, but the version in this PR already works OOTB on ubuntu w/ debug symbol packages installed.