### PR TITLE
Make `get_php_base_addr` more reliable

### DIFF
--- a/addr_objdump.c
+++ b/addr_objdump.c
@@ -93,20 +93,16 @@ static int get_php_bin_path(pid_t pid, char *path_root, char *path) {
 }
 
 static int get_php_base_addr(pid_t pid, char *path_root, char *path, uint64_t *raddr) {
-    /**
-     * This is very likely to be incorrect/incomplete. I thought the base
-     * address from `/proc/<pid>/maps` + the symbol address from `readelf` would
-     * lead to the actual memory address, but on at least one system I tested on
-     * this is not the case. On that system, working backwards from the address
-     * printed in `gdb`, it seems the missing piece was the 'virtual address' of
-     * the LOAD section in ELF headers. I suspect this may have to do with
-     * address relocation and/or a feature called 'prelinking', but not sure.
-     */
+    /* Note: This may be incomplete. It seems to work on x86_64 and aarch64.
+     *       It may not work if the PHP binary has multiple executable segments
+     *       for some reason. */
     char buf[PHPSPY_STR_SIZE];
     char arg_buf[PHPSPY_STR_SIZE];
     uint64_t start_addr;
     uint64_t virt_addr;
-    char *cmd_fmt = "grep -m1 ' '%s\\$ /proc/%d/maps";
+
+    /* find start addr of executable mapping */
+    char *cmd_fmt = "awk -vp=%s '$NF==p{if(index($2,\"x\")){print $1;exit}}' /proc/%d/maps";
     if (shell_escape(path, arg_buf, sizeof(arg_buf), "path")) {
         return 1;
     }
@@ -115,19 +111,18 @@ static int get_php_base_addr(pid_t pid, char *path_root, char *path, uint64_t *r
         return 1;
     }
     start_addr = strtoull(buf, NULL, 16);
+
+    /* find vaddr of executable segment */
+    cmd_fmt = "objdump -p %s | awk -va=0 '$1==\"LOAD\"{a=$5} $5==\"flags\"{if(index($6,\"x\")){print a;exit}}'";
     if (shell_escape(path_root, arg_buf, sizeof(arg_buf), "path_root")) {
         return 1;
     }
-    #if defined(__x86_64__)
-    cmd_fmt = "objdump -p %s | awk '/LOAD/{print $5; exit}'";
     if (popen_read_line(buf, sizeof(buf), cmd_fmt, arg_buf) != 0) {
         log_error("get_php_base_addr: Failed to get virt_addr\n");
         return 1;
     }
     virt_addr = strtoull(buf, NULL, 16);
-    #else
-    virt_addr = 0; /* aarch64 does not seem to use this */
-    #endif
+
     *raddr = start_addr - virt_addr;
     return 0;
 }


### PR DESCRIPTION
In order to calculate the base address of PHP's memory space, we were previously using the first PHP mapping in procfs_maps, which may not have been an executable range. Similarly we were using the first vaddr in ELF headers, which again may not have been an executable segment. In both cases we now look for the first entry with an "x" flag (executable).

For example, consider:

```
$ # procfs_maps
557a78c00000-557a78d5f000 r--p 00000000 fe:01 15623632                   /home/adam/php/bin/php
557a78e00000-557a7966d000 r-xp 00200000 fe:01 15623632                   /home/adam/php/bin/php
557a79800000-557a7a5b7000 r--p 00c00000 fe:01 15623632                   /home/adam/php/bin/php
557a7a72d000-557a7a800000 r--p 01b2d000 fe:01 15623632                   /home/adam/php/bin/php
557a7a800000-557a7a85d000 rw-p 01c00000 fe:01 15623632                   /home/adam/php/bin/php

$ # objdump -p
LOAD off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**21
     filesz 0x000000000015e438 memsz 0x000000000015e438 flags r--
LOAD off    0x0000000000200000 vaddr 0x0000000000200000 paddr 0x0000000000200000 align 2**21
     filesz 0x000000000086c87d memsz 0x000000000086c87d flags r-x
LOAD off    0x0000000000c00000 vaddr 0x0000000000c00000 paddr 0x0000000000c00000 align 2**21
     filesz 0x0000000000db63d8 memsz 0x0000000000db63d8 flags r--
LOAD off    0x0000000001b2ddc8 vaddr 0x0000000001b2ddc8 paddr 0x0000000001b2ddc8 align 2**21
     filesz 0x000000000012f186 memsz 0x0000000000156848 flags rw-
```

We were calculating base addr as:

    557a78c00000 - 0x0000000000000000 == 557a78c00000

but really we should have been calculating it as:

    557a78e00000 - 0x0000000000200000 == 557a78c00000

Note you get the same answer both ways, so this went unnoticed.

Recently aarch64 support was added, and on that architecture sometimes the executable mapping or executable vaddr record does not come first, leading to a bad base address. As the inline comment mentions, if PHP happens to have multiple executable segments, this may not work, since it just looks for the first executable record in both cases. I wouldn't expect that to happen in practice but I'm not sure. At least this seems to be an improvement over the existing function.