### PR TITLE
Report what the sampler is doing: exit summary, zero-capture warning, startup line

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ All with no changes to your application and minimal overhead.
       -q, --quiet                        Suppress errors and warnings on stderr
       -w, --libname-awk-patt=<patt>      Awk pattern to match name of PHP lib
                                            (default: libphp[78]?)
+      -W, --warn-no-traces-s=<sec>       Warn on stderr if no traces have been
+                                           captured after `sec` seconds
+                                           (default: 5; 0=never warn)
       -#, --comment=<any>                Ignored; intended for self-documenting
                                            commands
       -@, --nothing                      Ignored
@@ -164,7 +167,7 @@ All with no changes to your application and minimal overhead.
     # - - - - -
     ...
     ^C
-    main_pgrep finished gracefully
+    phpspy: 4812 samples in 48.31s across 9 pids: 4809 written, 3 empty, 0 filtered, 0 errored (0.31 ms/sample)
 
 ### Example (httpd)
 

--- a/pgrep.c
+++ b/pgrep.c
@@ -50,7 +50,6 @@ int main_pgrep() {
 
     deinit_work_threads();
 
-    log_error("main_pgrep finished gracefully\n");
     return 0;
 }
 

--- a/phpspy.c
+++ b/phpspy.c
@@ -38,6 +38,7 @@ int opt_continue_on_error = 0;
 int opt_fout_buffer_size = 4096;
 char *opt_libname_awk_patt = "libphp[78]?";
 int opt_quiet = 0;
+long opt_warn_no_traces_s = 5;
 
 int done = 0;
 int (*do_trace_ptr)(trace_context_t *context) = NULL;
@@ -46,6 +47,13 @@ glopeek_entry_t *glopeek_map = NULL;
 regex_t filter_re;
 int in_pgrep_mode = 0;
 uint64_t trace_count = 0;
+
+static pthread_mutex_t stats_mutex = PTHREAD_MUTEX_INITIALIZER;
+static trace_stats_t total_stats;
+static uint64_t total_targets = 0;
+static struct timespec total_start_time;
+static int no_traces_warned = 0;
+static uint64_t no_traces_suppressed = 0;
 
 static void parse_opts(int argc, char **argv);
 static int main_fork(int argc, char **argv);
@@ -61,6 +69,13 @@ static void calc_sleep_time(struct timespec *end, struct timespec *start, struct
 static void varpeek_add(char *varspec);
 static void glopeek_add(char *glospec);
 static int copy_proc_mem(pid_t pid, const char *what, void *raddr, void *laddr, size_t size);
+static int main_pid_inner(pid_t pid, trace_stats_t *stats);
+static uint64_t clock_diff_ns(struct timespec *start, struct timespec *end);
+static void stats_fold(trace_stats_t *stats);
+static void stats_report();
+static void warn_no_traces(pid_t pid, long secs);
+static void log_startup(trace_target_t *target);
+static int diagnostics_enabled();
 
 #ifdef USE_ZEND
 static int do_trace(trace_context_t *context);
@@ -83,6 +98,7 @@ static int do_trace_86(trace_context_t *context);
 int main(int argc, char **argv) {
     int rv;
     parse_opts(argc, argv);
+    clock_get(&total_start_time);
 
     if (opt_top_mode != 0) {
         rv = main_top(argc, argv);
@@ -98,6 +114,7 @@ int main(int argc, char **argv) {
         usage(stderr, 1);
         rv = 1;
     }
+    stats_report();
     cleanup();
     return rv;
 }
@@ -171,6 +188,9 @@ void usage(FILE *fp, int exit_code) {
     fprintf(fp, "  -q, --quiet                        Suppress errors and warnings on stderr\n");
     fprintf(fp, "  -w, --libname-awk-patt=<patt>      Awk pattern to match name of PHP lib\n");
     fprintf(fp, "                                       (default: %s)\n", opt_libname_awk_patt);
+    fprintf(fp, "  -W, --warn-no-traces-s=<sec>       Warn on stderr if no traces have been\n");
+    fprintf(fp, "                                       captured after `sec` seconds\n");
+    fprintf(fp, "                                       (default: %ld; 0=never warn)\n", opt_warn_no_traces_s);
     fprintf(fp, "  -#, --comment=<any>                Ignored; intended for self-documenting\n");
     fprintf(fp, "                                       commands\n");
     fprintf(fp, "  -@, --nothing                      Ignored\n");
@@ -268,6 +288,7 @@ static void parse_opts(int argc, char **argv) {
         { "peek-global",           required_argument, NULL, 'g' },
         { "top",                   no_argument,       NULL, 't' },
         { "libname-awk-patt",      required_argument, NULL, 'w' },
+        { "warn-no-traces-s",      required_argument, NULL, 'W' },
         { 0,                       0,                 0,    0   }
     };
     /* Parse options until the first non-option argument is reached. Effectively
@@ -280,7 +301,7 @@ static void parse_opts(int argc, char **argv) {
     while (
         optind < argc
         && argv[optind][0] == '-'
-        && (c = getopt_long(argc, argv, "hp:P:T:te:s:H:V:l:i:n:r:mo:O:E:x:a:1b:f:F:d:cqj:J:#:@vSe:g:tw:", long_opts, NULL)) != -1
+        && (c = getopt_long(argc, argv, "hp:P:T:te:s:H:V:l:i:n:r:mo:O:E:x:a:1b:f:F:d:cqj:J:#:@vSe:g:tw:W:", long_opts, NULL)) != -1
     ) {
         switch (c) {
             case 'h': usage(stdout, 0); break;
@@ -376,15 +397,27 @@ static void parse_opts(int argc, char **argv) {
             case 'g': glopeek_add(optarg); break;
             case 't': opt_top_mode = 1; break;
             case 'w': opt_libname_awk_patt = optarg; break;
+            case 'W': opt_warn_no_traces_s = strtol_with_min_or_exit("-W", optarg, 0); break;
         }
     }
 }
 
 int main_pid(pid_t pid) {
     int rv;
+    trace_stats_t stats;
+
+    memset(&stats, 0, sizeof(trace_stats_t));
+    rv = main_pid_inner(pid, &stats);
+    stats_fold(&stats);
+
+    return rv;
+}
+
+static int main_pid_inner(pid_t pid, trace_stats_t *stats) {
+    int rv;
     trace_context_t context;
-    struct timespec start_time, end_time, sleep_time, _stop_time, limit_time;
-    struct timespec *stop_time;
+    struct timespec start_time, end_time, sleep_time, _stop_time, limit_time, _warn_time;
+    struct timespec *stop_time, *warn_time;
 
     memset(&context, 0, sizeof(trace_context_t));
     context.target.pid = pid;
@@ -431,6 +464,8 @@ int main_pid(pid_t pid) {
     }
     #endif
 
+    log_startup(&context.target);
+
     /* calc stop_time */
     stop_time = NULL;
     if (in_pgrep_mode) {
@@ -443,6 +478,16 @@ int main_pid(pid_t pid) {
         clock_add(stop_time, &limit_time, stop_time);
     }
 
+    /* calc warn_time; the deadline for capturing at least one trace */
+    warn_time = NULL;
+    if (opt_warn_no_traces_s > 0) {
+        warn_time = &_warn_time;
+        limit_time.tv_sec = opt_warn_no_traces_s;
+        limit_time.tv_nsec = 0;
+        clock_get(warn_time);
+        clock_add(warn_time, &limit_time, warn_time);
+    }
+
     while (!done) {
         /* record start_time */
         clock_get(&start_time);
@@ -453,8 +498,42 @@ int main_pid(pid_t pid) {
         rv |= do_trace_ptr(&context);
         if (opt_pause) rv |= unpause_pid(pid);
 
+        clock_get(&end_time);
+        stats->trace_ns += clock_diff_ns(&start_time, &end_time);
+        stats->attempted += 1;
+
+        /* Classify the sample. A live target that is not executing PHP returns
+           PHPSPY_OK with depth 0 and emits nothing, so success cannot be read
+           from rv alone; and a failed read also leaves depth at 0, so errors
+           must be tested first or they masquerade as an idle target. */
+        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) {
+            /* not classified; the loop is about to break */
+        } else if ((rv & PHPSPY_ERR_SKIPPED) != 0) {
+            stats->filtered += 1;
+        } else if (rv != PHPSPY_OK) {
+            stats->errored += 1;
+        } else if (context.last_depth < 1) {
+            stats->empty += 1;
+        } else {
+            stats->written += 1;
+        }
+
         /* bail if pid died */
-        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) break;
+        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) {
+            if (!in_pgrep_mode && diagnostics_enabled()) {
+                log_error("phpspy: pid %d exited (%lu traces captured)\n",
+                    (int)pid, (unsigned long)stats->written);
+            }
+            break;
+        }
+
+        /* maybe warn that nothing at all is being captured */
+        if (warn_time && clock_diff(&start_time, warn_time) >= 1) {
+            if (stats->written + stats->filtered == 0) {
+                warn_no_traces(pid, opt_warn_no_traces_s);
+            }
+            warn_time = NULL; /* one-shot per target */
+        }
 
         /* maybe apply trace limit */
         if (opt_trace_limit > 0 && rv == PHPSPY_OK) {
@@ -620,6 +699,101 @@ static int find_addresses(trace_target_t *target) {
     return PHPSPY_OK;
 }
 
+static int diagnostics_enabled() {
+    /* top mode re-execs phpspy and counts stderr lines as errors, so it opts
+       out. Doubles as the escape hatch for wrappers that treat any stderr
+       output as failure. */
+    return getenv("PHPSPY_NO_SUMMARY") == NULL ? 1 : 0;
+}
+
+static void log_startup(trace_target_t *target) {
+    if (in_pgrep_mode || !diagnostics_enabled()) return; /* one line per worker would be noise */
+    log_error(
+        "phpspy: pid %d php %s executor_globals=0x%lx use_zend=%s\n",
+        (int)target->pid,
+        opt_phpv,
+        (unsigned long)target->executor_globals_addr,
+        #ifdef USE_ZEND
+        "y"
+        #else
+        "n"
+        #endif
+    );
+}
+
+static void warn_no_traces(pid_t pid, long secs) {
+    int expect = 0;
+    if (!diagnostics_enabled()) return;
+    /* in pgrep mode many workers can hit this at once; the first one speaks */
+    if (!__atomic_compare_exchange_n(&no_traces_warned, &expect, 1, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+        __atomic_add_fetch(&no_traces_suppressed, 1, __ATOMIC_SEQ_CST);
+        return;
+    }
+    log_error(
+        "phpspy: warning: pid %d: 0 traces captured in %lds; is the target executing PHP?\n"
+        "        (target blocked in a syscall, wrong pid, or a non-PHP process)\n",
+        (int)pid,
+        secs
+    );
+}
+
+static void stats_fold(trace_stats_t *stats) {
+    pthread_mutex_lock(&stats_mutex);
+    total_stats.attempted += stats->attempted;
+    total_stats.written   += stats->written;
+    total_stats.empty     += stats->empty;
+    total_stats.filtered  += stats->filtered;
+    total_stats.errored   += stats->errored;
+    total_stats.trace_ns  += stats->trace_ns;
+    total_targets += 1;
+    pthread_mutex_unlock(&stats_mutex);
+}
+
+static void stats_report() {
+    struct timespec now;
+    double elapsed_s, ms_per_sample;
+
+    if (!diagnostics_enabled()) return;
+    if (total_targets == 0) return; /* never got as far as tracing anything */
+
+    clock_get(&now);
+    elapsed_s = (double)clock_diff_ns(&total_start_time, &now) / 1000000000.0;
+    ms_per_sample = total_stats.attempted > 0
+        ? ((double)total_stats.trace_ns / (double)total_stats.attempted) / 1000000.0
+        : 0.0;
+
+    log_error(
+        "phpspy: %lu samples in %.2fs across %lu pid%s: "
+        "%lu written, %lu empty, %lu filtered, %lu errored (%.2f ms/sample)\n",
+        (unsigned long)total_stats.attempted,
+        elapsed_s,
+        (unsigned long)total_targets,
+        total_targets == 1 ? "" : "s",
+        (unsigned long)total_stats.written,
+        (unsigned long)total_stats.empty,
+        (unsigned long)total_stats.filtered,
+        (unsigned long)total_stats.errored,
+        ms_per_sample
+    );
+
+    if (no_traces_suppressed > 0) {
+        log_error("phpspy: (%lu more pids captured 0 traces)\n", (unsigned long)no_traces_suppressed);
+    }
+
+    if (total_stats.attempted == 0) {
+        log_error(
+            "phpspy: warning: no samples were taken; the target exited or could not be\n"
+            "        attached to before sampling began\n"
+        );
+    } else if (total_stats.written + total_stats.filtered == 0) {
+        log_error(
+            "phpspy: warning: captured 0 traces; the target may not have been executing PHP\n"
+            "        (blocked in a syscall, wrong pid, or a PHP build/extension that moves\n"
+            "        execution off the VM stack)\n"
+        );
+    }
+}
+
 static void clock_get(struct timespec *ts) {
     if (clock_gettime(CLOCK_MONOTONIC_RAW, ts) == -1) {
         log_perror("clock_gettime");
@@ -647,15 +821,17 @@ static int clock_diff(struct timespec *a, struct timespec *b) {
     return a->tv_sec > b->tv_sec ? 1 : -1;
 }
 
-static void calc_sleep_time(struct timespec *end, struct timespec *start, struct timespec *sleep) {
-    long end_ns, start_ns, sleep_ns;
-    if (end->tv_sec == start->tv_sec) {
-        sleep_ns = opt_sleep_ns - (end->tv_nsec - start->tv_nsec);
-    } else {
-        end_ns = (end->tv_sec * 1000000000UL) + (end->tv_nsec * 1UL);
-        start_ns = (start->tv_sec * 1000000000UL) + (start->tv_nsec * 1UL);
-        sleep_ns = opt_sleep_ns - (end_ns - start_ns);
+static uint64_t clock_diff_ns(struct timespec *start, struct timespec *end) {
+    if (clock_diff(end, start) < 0) {
+        return 0; /* non-monotonic; treat as zero elapsed */
     }
+    return ((uint64_t)(end->tv_sec - start->tv_sec) * 1000000000UL)
+         + (uint64_t)end->tv_nsec - (uint64_t)start->tv_nsec;
+}
+
+static void calc_sleep_time(struct timespec *end, struct timespec *start, struct timespec *sleep) {
+    long sleep_ns;
+    sleep_ns = opt_sleep_ns - (long)clock_diff_ns(start, end);
     if (sleep_ns < 0) {
         log_error("calc_sleep_time: Expected sleep_ns>0; decrease sample rate\n");
         sleep_ns = 0;

--- a/phpspy.h
+++ b/phpspy.h
@@ -148,6 +148,18 @@ typedef struct trace_target_s {
     uint64_t basic_functions_module_addr;
 } trace_target_t;
 
+/* Per-target sample tallies. Kept as a `main_pid` local (i.e. per worker
+   thread in `-P` mode) and folded into the global totals once per target, so
+   the sampling loop never touches shared memory. */
+typedef struct trace_stats_s {
+    uint64_t attempted;
+    uint64_t written;   /* emitted a stack */
+    uint64_t empty;     /* depth < 1; target was not executing PHP */
+    uint64_t filtered;  /* discarded by `-f`/`-F` */
+    uint64_t errored;
+    uint64_t trace_ns;  /* cumulative time spent inside do_trace */
+} trace_stats_t;
+
 typedef struct trace_context_s {
     trace_target_t target;
     struct {
@@ -162,6 +174,7 @@ typedef struct trace_context_s {
     const char *event_handler_opts;
     char buf[PHPSPY_STR_SIZE];
     size_t buf_len;
+    int last_depth; /* stack depth reached by the most recent do_trace */
 } trace_context_t;
 
 typedef struct addr_memo_s {

--- a/phpspy_trace.c
+++ b/phpspy_trace.c
@@ -31,6 +31,9 @@ static int do_trace(trace_context_t *context) {
     int rv, depth;
     zend_executor_globals executor_globals;
 
+    depth = 0;
+    context->last_depth = 0;
+
     try(rv, copy_executor_globals(context, &executor_globals));
     try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_STACK_BEGIN));
 
@@ -46,6 +49,7 @@ static int do_trace(trace_context_t *context) {
         } while(0)
 
         rv |= trace_stack(context, executor_globals.current_execute_data, &depth);
+        context->last_depth = depth;
         maybe_break_on_err();
         if (depth < 1) break;
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -31,34 +31,61 @@ actual=$(
 )
 
 exit_code=$?
-if [ -z "$non_zero_ok" -a "$exit_code" -ne 0 ]; then
+actual_err=$(cat test.err 2>/dev/null)
+
+if [ -n "$expected_exit_code" ]; then
+    if [ "$exit_code" -eq "$expected_exit_code" ]; then
+        echo -e "  \x1b[32mOK  \x1b[0m exit_code=$exit_code"
+    else
+        echo -e "  \x1b[31mERR \x1b[0m exit_code\nexpected=$expected_exit_code\n\nactual=$exit_code"
+        cat test.err >&2
+        exit 1
+    fi
+elif [ -z "$non_zero_ok" -a "$exit_code" -ne 0 ]; then
     echo -e "  \x1b[31mERR \x1b[0m exit_code=$exit_code"
     cat test.err >&2
     exit 1
 fi
 
-for testname in "${!expected[@]}"; do
-    expected_re="${expected[$testname]}"
-    if grep -Pq "$expected_re" <<<"$actual"; then
-        echo -e "  \x1b[32mOK  \x1b[0m $testname"
+# check_re <testname> <regex> <haystack> <want_match: 1|0> <haystack label>
+check_re() {
+    if grep -Pq "$2" <<<"$3"; then
+        found=1
     else
-        echo -e "  \x1b[31mERR \x1b[0m $testname\nexpected=$expected_re\n\nactual=\n$actual"
+        found=0
+    fi
+    if [ "$found" -eq "$4" ]; then
+        echo -e "  \x1b[32mOK  \x1b[0m $1"
+    elif [ "$4" -eq 1 ]; then
+        echo -e "  \x1b[31mERR \x1b[0m $1\nexpected=$2\n\n$5=\n$3"
+        exit 1
+    else
+        echo -e "  \x1b[31mERR \x1b[0m $1\nnot_expected=$2\n\n$5=\n$3"
         exit 1
     fi
+}
+
+for testname in "${!expected[@]}"; do
+    check_re "$testname" "${expected[$testname]}" "$actual" 1 actual
 done
 
 for testname in "${!not_expected[@]}"; do
-    not_expected_re="${not_expected[$testname]}"
-    if ! grep -Pq "$not_expected_re" <<<"$actual"; then
-        echo -e "  \x1b[32mOK  \x1b[0m $testname"
-    else
-        echo -e "  \x1b[31mERR \x1b[0m $testname\nnot_expected=$not_expected_re\n\nactual=\n$actual"
-        exit 1
-    fi
+    check_re "$testname" "${not_expected[$testname]}" "$actual" 0 actual
+done
+
+for testname in "${!expected_err[@]}"; do
+    check_re "$testname" "${expected_err[$testname]}" "$actual_err" 1 stderr
+done
+
+for testname in "${!not_expected_err[@]}"; do
+    check_re "$testname" "${not_expected_err[$testname]}" "$actual_err" 0 stderr
 done
 
 unset expected
 unset not_expected
+unset expected_err
+unset not_expected_err
+unset expected_exit_code
 unset need_ptrace
 unset use_timeout_s
 unset skip

--- a/tests/test_no_traces_warning.sh
+++ b/tests/test_no_traces_warning.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# A bogus executor_globals address makes every sample fail, which is the
+# observable equivalent of a target that never executes PHP on the VM stack
+# (e.g. one whose blocking calls are hooked by a coroutine extension).
+# Child mode keeps phpspy the parent, so no ptrace privileges are needed.
+phpspy_opts=(--limit=0 --time-limit-ms=2000 --rate-hz=5 --php-version=84 \
+             --addr-executor-globals=1 --warn-no-traces-s=1 \
+             -- $PHP -r 'usleep(3000000);')
+declare -A expected_err
+declare -A not_expected_err
+expected_err[warn           ]='0 traces captured in 1s'
+expected_err[warn_hint      ]='is the target executing PHP\?'
+expected_err[summary_zero   ]='0 written'
+expected_err[summary_warn   ]='captured 0 traces'
+# A failed read must be reported as an error, not as "target wasn't executing
+# PHP": both leave the depth at 0, but only one is a permissions/address
+# problem, and conflating them misdiagnoses it.
+expected_err[counted_errored]='[1-9]\d* errored'
+not_expected_err[not_empty   ]='[1-9]\d* empty'
+source $TEST_SH
+
+# --warn-no-traces-s=0 disables the warning
+phpspy_opts=(--limit=0 --time-limit-ms=2000 --rate-hz=5 --php-version=84 \
+             --addr-executor-globals=1 --warn-no-traces-s=0 \
+             -- $PHP -r 'usleep(3000000);')
+declare -A not_expected_err
+not_expected_err[no_warn     ]='0 traces captured in'
+source $TEST_SH
+
+# a healthy target must not warn
+phpspy_opts=(--limit=0 --time-limit-ms=2000 --warn-no-traces-s=1 -- $PHP -r 'usleep(3000000);')
+declare -A expected
+declare -A not_expected_err
+expected[frame_0            ]='^0 usleep <internal>:-1$'
+not_expected_err[no_warn     ]='0 traces captured in'
+source $TEST_SH

--- a/tests/test_startup_line.sh
+++ b/tests/test_startup_line.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+phpspy_opts=(-- $PHP -r 'usleep(2000000);')
+declare -A expected_err
+expected_err[startup        ]='^phpspy: pid \d+ php \S+ executor_globals=0x[0-9a-f]+ use_zend=[yn]$'
+source $TEST_SH
+
+# -q silences it
+phpspy_opts=(--quiet -- $PHP -r 'usleep(2000000);')
+declare -A not_expected_err
+not_expected_err[no_startup  ]='executor_globals='
+source $TEST_SH

--- a/tests/test_summary.sh
+++ b/tests/test_summary.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+phpspy_opts=(-- $PHP -r 'usleep(2000000);')
+declare -A expected_err
+expected_err[summary        ]='^phpspy: \d+ samples in \d+\.\d+s across \d+ pid'
+expected_err[written        ]='\d+ written, \d+ empty, \d+ filtered'
+expected_err[ms_per_sample  ]='\(\d+\.\d+ ms/sample\)$'
+source $TEST_SH
+
+# -q silences the summary
+phpspy_opts=(--quiet -- $PHP -r 'usleep(2000000);')
+declare -A not_expected_err
+not_expected_err[no_summary  ]='samples in'
+source $TEST_SH
+
+# PHPSPY_NO_SUMMARY silences it too (this is what top mode uses)
+PHPSPY_NO_SUMMARY=1
+export PHPSPY_NO_SUMMARY
+phpspy_opts=(-- $PHP -r 'usleep(2000000);')
+declare -A expected
+declare -A not_expected_err
+expected[frame_0            ]='^0 usleep <internal>:-1$'
+not_expected_err[no_summary  ]='samples in'
+source $TEST_SH
+unset PHPSPY_NO_SUMMARY

--- a/top.c
+++ b/top.c
@@ -135,6 +135,10 @@ static int fork_child(int argc, char **argv, pid_t *pid, int *outfd, int *errfd)
         dup2(perr[1], STDERR_FILENO);
         close(perr[1]);
 
+        /* we count child stderr lines as errors, so suppress the startup line
+           and exit summary in the child */
+        setenv("PHPSPY_NO_SUMMARY", "1", 1);
+
         execvp(argv[0], argv);
         log_perror("execvp");
         exit(1);


### PR DESCRIPTION
phpspy can sample a process hundreds of times, write an empty file, and never say a word. I hit this profiling a large CLI tool and lost a fair amount of time to it, so this makes the sampler account for what it did.

### The problem

A target blocked in a syscall, an attach to the wrong pid of a process that re-execs itself, and a PHP build whose extensions move execution off the VM stack all look identical from outside: phpspy sits there producing nothing. There is currently no signal at all — not while running, not at exit, not in the exit status.

### What this adds

```
$ phpspy -p 318501
phpspy: pid 318501 php 84 executor_globals=0x7f2b1c0e75e0 use_zend=n
phpspy: warning: pid 318501: 0 traces captured in 5s; is the target executing PHP?
        (target blocked in a syscall, wrong pid, or a non-PHP process)
^C
phpspy: 512 samples in 5.17s across 1 pid: 0 written, 512 empty, 0 filtered, 0 errored (0.12 ms/sample)
```

- a per-sample tally, reported at exit
- a one-shot warning when nothing has been captured after `-W` seconds (default 5, `0` disables)
- a startup line naming the pid, PHP version and `executor_globals` address, which makes a wrong-pid attach obvious immediately

### Notes for review

**The `empty` bucket is the point.** A live target that is not executing PHP returns `PHPSPY_OK` with depth 0 and emits nothing, so success cannot be inferred from `rv` alone — `do_trace` now records the depth it reached. Errors are classified *before* depth, because a failed read also leaves depth at 0, and reporting a permissions problem as "not executing PHP" would be the same misdiagnosis in a new costume.

**No shared writes added to the sampling loop.** Counters live in a `trace_stats_t` that is a `main_pid` local — already per worker thread in `-P` mode — and are folded into the totals once per target under a mutex.

**Deliberately no overhead percentage.** I wanted one, but `trace_ns / wall_ns` does not include the contention `process_vm_readv` causes on the target's memory-map lock; on a large, actively-allocating target it reports a few percent where the measured slowdown is nearly 2×. A confidently wrong number seemed worse than none, so the summary reports `ms/sample` and leaves interpretation to the reader.

**Output compatibility.** Nothing changes on stdout; all of this goes to stderr, honours `-q`, and can be suppressed with `PHPSPY_NO_SUMMARY=1`. `top` mode sets that on its child, since it counts child stderr lines as errors. The content-free `main_pgrep finished gracefully` line is replaced by the summary (also updated in the README).

`tests/test.sh` grows `expected_err` / `not_expected_err` / `expected_exit_code`, since diagnostics go to stderr and there was previously no way to assert on them.

### Testing

`make test` passes (17/17, including three new files) under both `make` and `USE_ZEND=1 make` against php8.3 and php8.4.

This is the first of a short series — buffer handling, child-mode exit status, `-P` robustness and a few features follow, each self-contained. Happy to reshape any of it.
