### PR TITLE
Truncate over-budget traces instead of dropping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ All with no changes to your application and minimal overhead.
       -a, --addr-sapi-globals=<hex>      Set address of sapi_globals in hex
                                            (default: 0; 0=find dynamically)
       -1, --single-line                  Output in single-line mode
-      -b, --buffer-size=<size>           Set output buffer size to `size`.
+      -b, --buffer-size=<size>           Set max output bytes per trace to
+                                           `size`. This is a per-trace budget,
+                                           not a stream buffer: a trace that
+                                           exceeds it is emitted truncated, with
+                                           a `# truncated = 1` marker. Deep
+                                           stacks run ~100-140 bytes per frame.
                                            Note: In `-P` mode, setting this
                                            above PIPE_BUF (4096) may lead to
                                            interlaced writes across threads

--- a/event_fout.c
+++ b/event_fout.c
@@ -6,7 +6,10 @@ typedef struct event_handler_fout_udata_s {
     char *cur;
     size_t buf_size;
     size_t rem;
+    size_t reserve; /* epilogue bytes withheld from `rem` until STACK_END */
     int use_mutex;
+    int truncated;  /* this trace overflowed `-b` */
+    int warned;     /* the overflow has been reported once */
 } event_handler_fout_udata_t;
 
 static int event_handler_fout_write(event_handler_fout_udata_t *udata);
@@ -27,6 +30,44 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
         return PHPSPY_ERR;
     }
     len = 0;
+
+    /* Absorb buffer overflow instead of propagating it: a trace that does not
+       fit in `-b` is emitted truncated (and flagged) rather than dropped
+       wholesale. Bailing out of the handler would skip STACK_END, and hence
+       the write, discarding the entire sample -- which silently biases
+       profiles against deep stacks. */
+    #define try_trunc(__rv, __call) do {                     \
+        if (((__rv) = (__call)) != 0) {                       \
+            if (((__rv) & PHPSPY_ERR_BUF_FULL) != 0) {        \
+                udata->truncated = 1;                         \
+                if (!udata->warned) {                         \
+                    udata->warned = 1;                        \
+                    log_error(                                \
+                        "event_handler_fout: Trace exceeds --buffer-size=%d; truncating" \
+                        " (further such messages suppressed)\n",                         \
+                        opt_fout_buffer_size                  \
+                    );                                        \
+                }                                             \
+                return PHPSPY_OK;                             \
+            }                                                 \
+            return (__rv);                                    \
+        }                                                     \
+    } while (0)
+
+    /* once truncated, appending anything further would emit records out of
+       order, so drop the rest of the trace's payload */
+    switch (event_type) {
+        case PHPSPY_TRACE_EVENT_FRAME:
+        case PHPSPY_TRACE_EVENT_VARPEEK:
+        case PHPSPY_TRACE_EVENT_GLOPEEK:
+        case PHPSPY_TRACE_EVENT_REQUEST:
+        case PHPSPY_TRACE_EVENT_MEM:
+            if (udata->truncated) return PHPSPY_OK;
+            break;
+        default:
+            break;
+    }
+
     switch (event_type) {
         case PHPSPY_TRACE_EVENT_INIT:
             try(rv, event_handler_fout_open(&fd));
@@ -35,7 +76,13 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
             udata->buf_size = opt_fout_buffer_size + 1; /* + 1 for null char */
             udata->buf = malloc(udata->buf_size);
             udata->cur = udata->buf;
-            udata->rem = udata->buf_size;
+            /* Withhold a little tail room so the truncation marker and the
+               trace delimiter always fit. Deliberately taken out of the
+               existing budget rather than added to it: growing the buffer past
+               PIPE_BUF would reintroduce interlaced writes in `-P` mode. Tiny
+               buffers keep the old all-or-nothing behavior. */
+            udata->reserve = opt_fout_buffer_size >= 128 ? PHPSPY_FOUT_EPILOGUE_RESERVE : 0;
+            udata->rem = udata->buf_size - udata->reserve;
             udata->use_mutex = context->event_handler_opts != NULL
                 && strchr(context->event_handler_opts, 'm') != NULL ? 1 : 0;
             context->event_udata = udata;
@@ -43,11 +90,12 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
         case PHPSPY_TRACE_EVENT_STACK_BEGIN:
             udata->cur = udata->buf;
             udata->cur[0] = '\0';
-            udata->rem = udata->buf_size;
+            udata->rem = udata->buf_size - udata->reserve;
+            udata->truncated = 0;
             break;
         case PHPSPY_TRACE_EVENT_FRAME:
             frame = &context->event.frame;
-            try(rv, event_handler_fout_snprintf(
+            try_trunc(rv, event_handler_fout_snprintf(
                 &udata->cur,
                 &udata->rem,
                 &len,
@@ -60,10 +108,10 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                 (int)frame->loc.file_len, frame->loc.file,
                 frame->loc.lineno
             ));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
             break;
         case PHPSPY_TRACE_EVENT_VARPEEK:
-            try(rv, event_handler_fout_snprintf(
+            try_trunc(rv, event_handler_fout_snprintf(
                 &udata->cur,
                 &udata->rem,
                 &len,
@@ -74,10 +122,10 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                 context->event.varpeek.zval_str_len,
                 context->event.varpeek.zval_str
             ));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
             break;
         case PHPSPY_TRACE_EVENT_GLOPEEK:
-            try(rv, event_handler_fout_snprintf(
+            try_trunc(rv, event_handler_fout_snprintf(
                 &udata->cur,
                 &udata->rem,
                 &len,
@@ -87,23 +135,23 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                 context->event.glopeek.zval_str_len,
                 context->event.glopeek.zval_str
             ));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
             break;
         case PHPSPY_TRACE_EVENT_REQUEST:
             request = &context->event.request;
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# uri = %s", request->uri));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# path = %s", request->path));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# qstring = %s", request->qstring));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# cookie = %s", request->cookie));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# ts = %f", request->ts));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# uri = %s", request->uri));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# path = %s", request->path));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# qstring = %s", request->qstring));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# cookie = %s", request->cookie));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# ts = %f", request->ts));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
             break;
         case PHPSPY_TRACE_EVENT_MEM:
-            try(rv, event_handler_fout_snprintf(
+            try_trunc(rv, event_handler_fout_snprintf(
                 &udata->cur,
                 &udata->rem,
                 &len,
@@ -112,7 +160,7 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                 (uint64_t)context->event.mem.size,
                 (uint64_t)context->event.mem.peak
             ));
-            try(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+            try_trunc(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
             break;
         case PHPSPY_TRACE_EVENT_STACK_END:
             if (udata->cur == udata->buf) {
@@ -124,7 +172,12 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                 if (opt_filter_negate == 0 && rv != 0) return PHPSPY_ERR_SKIPPED;
                 if (opt_filter_negate != 0 && rv == 0) return PHPSPY_ERR_SKIPPED;
             }
+            udata->rem += udata->reserve; /* release the epilogue reserve */
             do {
+                if (udata->truncated) {
+                    try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# truncated = 1"));
+                    try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
+                }
                 if (opt_verbose_fields_ts) {
                     gettimeofday(&tv, NULL);
                     try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# trace_ts = %f", (double)(tv.tv_sec + tv.tv_usec / 1000000.0)));
@@ -134,9 +187,23 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
                     try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 1, "# pid = %d", context->target.pid));
                     try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_frame_delim));
                 }
-                try_break(rv, event_handler_fout_snprintf(&udata->cur, &udata->rem, &len, 0, "%c", opt_trace_delim));
             } while (0);
+            /* The trace delimiter is not optional: without it consumers merge
+               this trace into the next one. Overwrite the last byte if that is
+               the only way to fit it. */
+            if (udata->rem >= 2) {
+                *udata->cur++ = opt_trace_delim;
+                *udata->cur = '\0';
+                udata->rem -= 1;
+            } else {
+                *(udata->cur - 1) = opt_trace_delim;
+            }
             try(rv, event_handler_fout_write(udata));
+            /* report truncation upward so the sample is tallied and counted
+               against `-l`, without discarding what we just wrote */
+            if (udata->truncated) {
+                return PHPSPY_ERR_BUF_FULL;
+            }
             break;
         case PHPSPY_TRACE_EVENT_DEINIT:
             close(udata->fd);
@@ -144,6 +211,7 @@ int event_handler_fout(struct trace_context_s *context, int event_type) {
             free(udata);
             break;
     }
+    #undef try_trunc
     return PHPSPY_OK;
 }
 
@@ -185,7 +253,11 @@ static int event_handler_fout_snprintf(char **s, size_t *n, size_t *ret_len, int
     va_end(vl);
 
     if (len < 0 || (size_t)len >= *n) {
-        log_error("event_handler_fout_snprintf: Not enough space in buffer; truncating\n");
+        /* vsnprintf has already written a truncated copy at *s; re-terminate
+           so the partial record is not visible to the filter or the write.
+           The caller reports this (once per handler), not us: at 99 Hz on a
+           deep stack this branch is hit for every frame of every sample. */
+        **s = '\0';
         return PHPSPY_ERR | PHPSPY_ERR_BUF_FULL;
     }
 

--- a/phpspy.c
+++ b/phpspy.c
@@ -153,7 +153,12 @@ void usage(FILE *fp, int exit_code) {
     fprintf(fp, "  -a, --addr-sapi-globals=<hex>      Set address of sapi_globals in hex\n");
     fprintf(fp, "                                       (default: %lu; 0=find dynamically)\n", opt_executor_globals_addr);
     fprintf(fp, "  -1, --single-line                  Output in single-line mode\n");
-    fprintf(fp, "  -b, --buffer-size=<size>           Set output buffer size to `size`.\n");
+    fprintf(fp, "  -b, --buffer-size=<size>           Set max output bytes per trace to\n");
+    fprintf(fp, "                                       `size`. This is a per-trace budget,\n");
+    fprintf(fp, "                                       not a stream buffer: a trace that\n");
+    fprintf(fp, "                                       exceeds it is emitted truncated, with\n");
+    fprintf(fp, "                                       a `# truncated = 1` marker. Deep\n");
+    fprintf(fp, "                                       stacks run ~100-140 bytes per frame.\n");
     fprintf(fp, "                                       Note: In `-P` mode, setting this\n");
     fprintf(fp, "                                       above PIPE_BUF (4096) may lead to\n");
     fprintf(fp, "                                       interlaced writes across threads\n");
@@ -457,7 +462,7 @@ int main_pid(pid_t pid) {
         if ((rv & PHPSPY_ERR_PID_DEAD) != 0) break;
 
         /* maybe apply trace limit */
-        if (opt_trace_limit > 0 && rv == PHPSPY_OK) {
+        if (opt_trace_limit > 0 && PHPSPY_TRACE_COUNTED(rv)) {
             if (in_pgrep_mode) {
                 __atomic_add_fetch(&trace_count, 1, __ATOMIC_SEQ_CST);
             } else {

--- a/phpspy.h
+++ b/phpspy.h
@@ -56,6 +56,15 @@
 #define PHPSPY_ERR_BUF_FULL 4
 #define PHPSPY_ERR_SKIPPED  8
 
+/* Tail room event_fout withholds so a truncated trace can still carry its
+   epilogue: `# truncated = 1` (16), `# trace_ts = <float>` (31), `# pid = N`
+   (16) and the trace delimiter, each with its frame delimiter. */
+#define PHPSPY_FOUT_EPILOGUE_RESERVE 80
+
+/* A sample that reached output, whether or not it fit in `-b`. Traces dropped
+   by `-f`/`-F` deliberately do not count. */
+#define PHPSPY_TRACE_COUNTED(__rv) ((__rv) == PHPSPY_OK || ((__rv) & PHPSPY_ERR_BUF_FULL) != 0)
+
 #define PHPSPY_TRACE_EVENT_INIT        0
 #define PHPSPY_TRACE_EVENT_STACK_BEGIN 1
 #define PHPSPY_TRACE_EVENT_FRAME       2

--- a/phpspy_trace.c
+++ b/phpspy_trace.c
@@ -38,7 +38,6 @@ static int do_trace(trace_context_t *context) {
     do {
         #define maybe_break_on_err() do {                      \
             if (   (rv & PHPSPY_ERR_PID_DEAD) != 0             \
-                || (rv & PHPSPY_ERR_BUF_FULL) != 0             \
                 || (rv != PHPSPY_OK && !opt_continue_on_error) \
             ) {                                                \
                 goto do_trace_end;                             \
@@ -68,7 +67,9 @@ static int do_trace(trace_context_t *context) {
     } while (0);
 
 do_trace_end:
-    if (rv == PHPSPY_OK || opt_continue_on_error) {
+    /* a handler that ran out of output space still has a partial trace worth
+       emitting, so let it decide at STACK_END */
+    if (rv == PHPSPY_OK || (rv & PHPSPY_ERR_BUF_FULL) != 0 || opt_continue_on_error) {
         try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_STACK_END));
     }
 

--- a/tests/test_buffer_full.sh
+++ b/tests/test_buffer_full.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-phpspy_opts=(--continue-on-error --buffer-size=24 -- $PHP -r 'usleep(1000000);')
+phpspy_opts=(--continue-on-error --buffer-size=24 -- $PHP -r 'usleep(2000000);')
 declare -A expected
 declare -A not_expected
 expected[frame_0        ]='^0 usleep <internal>:-1$'
 not_expected[no_frame_1 ]='^1 <main> <internal>:-1$'
 source $TEST_SH
 
-phpspy_opts=(--buffer-size=24 -- $PHP -r 'usleep(1000000);')
+# Without --continue-on-error an over-budget trace used to be discarded
+# entirely; it is now emitted truncated. A buffer this small leaves no room for
+# the `# truncated = 1` marker itself (see test_truncate.sh for that).
+phpspy_opts=(--buffer-size=24 -- $PHP -r 'usleep(2000000);')
+declare -A expected
 declare -A not_expected
-not_expected[anything]='^.+$'
+expected[frame_0        ]='^0 usleep <internal>:-1$'
+not_expected[no_frame_1 ]='^1 <main> <internal>:-1$'
 source $TEST_SH

--- a/tests/test_truncate.sh
+++ b/tests/test_truncate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+php_src='function f($n){ if($n) f($n-1); else usleep(2000000); } f(20);'
+
+# A deep stack that does not fit in --buffer-size must still be emitted, with
+# the innermost frames kept and a marker appended.
+phpspy_opts=(--buffer-size=256 -- $PHP -r "$php_src")
+declare -A expected
+expected[frame_0        ]='^0 usleep <internal>:-1$'
+expected[truncated      ]='^# truncated = 1$'
+source $TEST_SH
+
+# A buffer big enough for the whole stack must not truncate.
+phpspy_opts=(--buffer-size=65536 -- $PHP -r "$php_src")
+declare -A expected
+declare -A not_expected
+expected[frame_0        ]='^0 usleep <internal>:-1$'
+expected[outermost      ]='^22 <main> <internal>:-1$'
+not_expected[no_marker  ]='^# truncated = 1$'
+source $TEST_SH
+
+# Truncated traces must still terminate properly, or downstream consumers merge
+# them. Assert one trace delimiter (blank line) per depth-0 frame, and that
+# every sample survives a stackcollapse round-trip.
+flame_out=$(mktemp)
+on_exit() { rm -f $flame_out; }
+trap on_exit EXIT
+
+$PHPSPY --limit=0 --time-limit-ms=2000 --buffer-size=256 \
+    -O/dev/null -E/dev/null -- $PHP -r "$php_src" >$flame_out 2>/dev/null
+
+n_traces=$(grep -c '^0 ' $flame_out)
+n_delims=$(grep -c '^$' $flame_out)
+if [ "$n_traces" -gt 0 -a "$n_traces" -eq "$n_delims" ]; then
+    echo -e "  \x1b[32mOK  \x1b[0m trace_delims ($n_traces traces, $n_delims delimiters)"
+else
+    echo -e "  \x1b[31mERR \x1b[0m trace_delims\ntraces=$n_traces delimiters=$n_delims"
+    exit 1
+fi
+
+REPO=$(dirname $(dirname $TEST_SH))
+n_collapsed=$($REPO/stackcollapse-phpspy.pl <$flame_out | awk '{s+=$NF} END{print s+0}')
+if [ "$n_collapsed" -eq "$n_traces" ]; then
+    echo -e "  \x1b[32mOK  \x1b[0m stackcollapse ($n_collapsed samples)"
+else
+    echo -e "  \x1b[31mERR \x1b[0m stackcollapse\nexpected=$n_traces samples\n\nactual=$n_collapsed"
+    exit 1
+fi


### PR DESCRIPTION
A trace larger than `-b` is discarded in full, while the log line says `truncating`.

The buffer is per-trace — reset at `STACK_BEGIN`, written once at `STACK_END` — so an overflow during a frame returns out of the handler via `try`, `STACK_END` never runs, and `event_handler_fout_write` is never called.

### Why it matters

Deep stacks are dropped preferentially, so the profile is biased against exactly the recursive code you opened the profiler to look at. A 60-frame recursion, measured before the change:

| `-b` | traces written | dropped |
|---|---|---|
| 4096 (default) | **3** | 143 |
| 65536 | 145 | 0 |

98% of samples lost at the default buffer size, and the only hint is a log line whose wording implies partial data was kept. After the change both sizes yield 146 traces, and every sample survives a `stackcollapse-phpspy.pl` round-trip.

`-l` was affected too: `trace_count` was gated on `rv == PHPSPY_OK`, so on such a target the limit could never be reached and `--limit=N` ran until the process died.

### Approach

The handler absorbs the overflow — emits the frames that fit, appends `# truncated = 1`, and reports the truncation upward so the sample is still tallied and still counts toward `-l`.

Details that took some care, and are probably where review is best spent:

- **The epilogue reserve comes out of the existing budget, not on top of it.** Growing the buffer past `PIPE_BUF` would reintroduce interlaced writes in `-P` mode — the hazard the `-b` help text already warns about. Buffers under 128 bytes keep the old all-or-nothing behaviour.
- **Once a trace truncates, later records are dropped too.** Otherwise a short frame fits after a long one was refused, and the stack comes out with a silent hole in it rather than a clean tail.
- **`vsnprintf` has already written its truncated copy** by the time it reports failure, so the buffer is re-terminated at the cursor — otherwise `-f` matches against a partial frame that is never written.
- **The trace delimiter is now guaranteed**, overwriting the last byte if that is the only way to fit it. This is a *pre-existing* bug independent of the above: when the `-d` epilogue overflowed, `try_break` skipped the delimiter and two traces merged into one in the stream.
- **One log line per handler instead of per frame.** At 99 Hz on a deep stack the old one fires for every frame of every sample.

### Compatibility

`# truncated = 1` is a `#` comment line, so `stackcollapse-phpspy.pl` and `top.c`'s parser both already skip it, exactly as they do for `# uri = …`.

**One behaviour change worth calling out explicitly:** `tests/test_buffer_full.sh` currently asserts that an over-budget trace produces *nothing at all* (`not_expected[anything]='^.+$'`). That is the behaviour this PR changes, so its second case is rewritten. If you would rather keep the drop as the default and put truncation behind a flag, say so and I will rework it — but I think a silently discarded sample is the wrong default for a sampling profiler.

### Testing

`make test` passes (15/15) under both `make` and `USE_ZEND=1 make` against php8.3 and php8.4. `tests/test_truncate.sh` covers the marker, the delimiter invariant, and that no samples are lost in the round-trip.

Independent of #156 — they touch different code and can merge in either order.
