### PR TITLE
Child mode: report the child's exit status, and say why it failed

### DIFF
--- a/phpspy.c
+++ b/phpspy.c
@@ -454,7 +454,12 @@ int main_pid(pid_t pid) {
         if (opt_pause) rv |= unpause_pid(pid);
 
         /* bail if pid died */
-        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) break;
+        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) {
+            if (!in_pgrep_mode) {
+                log_error("phpspy: pid %d exited\n", (int)pid);
+            }
+            break;
+        }
 
         /* maybe apply trace limit */
         if (opt_trace_limit > 0 && rv == PHPSPY_OK) {
@@ -508,13 +513,40 @@ static int main_fork(int argc, char **argv) {
         log_perror("fork");
         exit(1);
     }
-    waitpid(fork_pid, &status, 0);
+    if (waitpid(fork_pid, &status, 0) < 0) {
+        log_perror("main_fork: waitpid");
+        return PHPSPY_ERR;
+    }
+
+    /* The child exits before exec if it could not redirect its stdio, so say
+       so rather than pressing on and probing a zombie. */
+    if (WIFEXITED(status)) {
+        log_error("main_fork: Child exited with status %d before exec; see errors above\n", WEXITSTATUS(status));
+        return WEXITSTATUS(status) != 0 ? WEXITSTATUS(status) : 1;
+    }
+    if (WIFSIGNALED(status)) {
+        log_error("main_fork: Child killed by signal %d before exec\n", WTERMSIG(status));
+        return 128 + WTERMSIG(status);
+    }
     if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP) {
         log_error("main_fork: Expected SIGTRAP from child\n");
     }
+
     ptrace(PTRACE_DETACH, fork_pid, NULL, NULL);
     rv = main_pid(fork_pid);
-    waitpid(fork_pid, NULL, 0);
+    waitpid(fork_pid, &status, 0);
+
+    /* Act as a wrapper and report the child's status, the way strace(1) and
+       time(1) do. A profiling failure is reported on stderr; it must not mask
+       the exit code of the command being profiled, not least because a
+       short-lived child routinely exits before phpspy finishes attaching. */
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+
     return rv;
 }
 
@@ -584,7 +616,12 @@ static void redirect_child_stdio(int proc_fd, char *opt_path) {
         }
     }
     if ((redir_file = fopen(redir_path, "w")) == NULL) {
-        log_perror("fopen");
+        log_error(
+            "redirect_child_stdio: Failed to open '%s' for child %s: %s\n",
+            redir_path,
+            proc_fd == STDOUT_FILENO ? "stdout (-O)" : "stderr (-E)",
+            strerror(errno)
+        );
         free(redir_path);
         exit(1);
     }
@@ -738,6 +775,7 @@ static void glopeek_add(char *glospec) {
 static int copy_proc_mem(pid_t pid, const char *what, void *raddr, void *laddr, size_t size) {
     struct iovec local[1];
     struct iovec remote[1];
+    ssize_t nread;
 
     if (raddr == NULL) {
         log_error("copy_proc_mem: Not copying %s; raddr is NULL\n", what);
@@ -749,12 +787,24 @@ static int copy_proc_mem(pid_t pid, const char *what, void *raddr, void *laddr, 
     remote[0].iov_base = raddr;
     remote[0].iov_len = size;
 
-    if (process_vm_readv(pid, local, 1, remote, 1, 0) == -1) {
-        if (errno == ESRCH) { /* No such process */
-            log_perror("process_vm_readv");
+    nread = process_vm_readv(pid, local, 1, remote, 1, 0);
+
+    if (nread == -1) {
+        if (errno == ESRCH) {
+            /* The target is gone. This is the ordinary end of a child-mode
+               run, so it is reported once by the sampling loop rather than
+               looking like a failure here. */
             return PHPSPY_ERR | PHPSPY_ERR_PID_DEAD;
         }
         log_error("copy_proc_mem: Failed to copy %s; err=%s raddr=%p size=%lu\n", what, strerror(errno), raddr, size);
+        return PHPSPY_ERR;
+    }
+
+    if ((size_t)nread != size) {
+        /* A partial read (e.g. straddling a mapping boundary) would leave the
+           tail of the destination as-is; callers treat those bytes as pointers
+           into the target, so refuse the sample instead. */
+        log_error("copy_proc_mem: Short read of %s; got %ld of %lu bytes; raddr=%p\n", what, (long)nread, size, raddr);
         return PHPSPY_ERR;
     }
 

--- a/tests/test_child_exit_status.sh
+++ b/tests/test_child_exit_status.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# In child mode phpspy is a wrapper, so `$?` must be the command's own status.
+# Written standalone rather than through test.sh, which has no exit-code
+# assertion of its own.
+
+check_exit() { # <label> <expected> <php args...>
+    local label="$1" want="$2"; shift 2
+    $PHPSPY --limit=0 --quiet -O/dev/null -E/dev/null -o /dev/null -- "$@" >/dev/null 2>&1
+    local got=$?
+    if [ "$got" -eq "$want" ]; then
+        echo -e "  \x1b[32mOK  \x1b[0m $label (exit=$got)"
+    else
+        echo -e "  \x1b[31mERR \x1b[0m $label\nexpected=$want\n\nactual=$got"
+        exit 1
+    fi
+}
+
+check_exit exit_0   0   $PHP -r 'exit(0);'
+check_exit exit_3   3   $PHP -r 'exit(3);'
+check_exit exit_42  42  $PHP -r 'exit(42);'
+
+# a child killed by a signal reports 128+signum
+if $PHP -r 'exit(function_exists("posix_kill") ? 0 : 1);' 2>/dev/null; then
+    check_exit signalled 143 $PHP -r 'posix_kill(posix_getpid(), SIGTERM); usleep(5000000);'
+else
+    echo -e "  \x1b[33mSKIP\x1b[0m signalled (ext/posix not available)"
+fi
+
+# a target that outlives sampling still reports its own status
+$PHPSPY --limit=0 --time-limit-ms=500 --quiet -O/dev/null -E/dev/null -o /dev/null \
+    -- $PHP -r 'usleep(1500000); exit(7);' >/dev/null 2>&1
+got=$?
+if [ "$got" -eq 7 ]; then
+    echo -e "  \x1b[32mOK  \x1b[0m outlives_sampling (exit=$got)"
+else
+    echo -e "  \x1b[31mERR \x1b[0m outlives_sampling\nexpected=7\n\nactual=$got"
+    exit 1
+fi
+
+# an unwritable -E must name the path, and must not then probe a zombie
+err=$($PHPSPY --limit=0 -O/dev/null -E/nonexistent-dir/x.err -o /dev/null \
+    -- $PHP -r 'usleep(100000);' 2>&1 >/dev/null)
+if grep -q "nonexistent-dir/x.err" <<<"$err" && ! grep -q 'get_php_bin_path' <<<"$err"; then
+    echo -e "  \x1b[32mOK  \x1b[0m names_unwritable_path"
+else
+    echo -e "  \x1b[31mERR \x1b[0m names_unwritable_path\n$err"
+    exit 1
+fi


### PR DESCRIPTION
Three things that make `phpspy -- cmd` awkward, all in the same area.

### 1. The child's exit status is discarded

`main_fork` calls `waitpid(fork_pid, NULL, 0)`, so:

```
$ phpspy -- php -r 'exit(3);'; echo $?
0
$ phpspy -- php broken.php; echo $?     # php exits 255
0
```

That makes phpspy hard to drop into a pipeline or a CI job. It now reports the child's status, as `strace(1)` and `time(1)` do.

I went back and forth on precedence and settled on the child's status winning over phpspy's own error. The reason is practical: a short-lived child routinely exits before phpspy finishes resolving symbols, so `main_pid` returns an error for exactly the quick commands most likely to be scripted. Preferring phpspy's error would mean the status is lost in the common case. Profiling failures are still reported on stderr.

### 2. The normal end of a run looks like an error

`copy_proc_mem` prints `process_vm_readv: No such process` on ESRCH — which is what happens at the end of *every* successful child-mode run. ESRCH is now silent there, and the sampling loop reports the exit once instead:

```
phpspy: pid 10652 exited
```

### 3. A failed stdio redirect doesn't say what it couldn't open

The defaults `-O phpspy.%d.out` / `-E phpspy.%d.err` are relative to the working directory, so running from somewhere unwritable gives a bare `fopen: Permission denied` with no path. Worse, phpspy then carries on into `main_pid` against a child that never execed, so the next thing on screen is an awk/objdump cascade that points at ptrace rather than at file permissions:

```
fopen: Permission denied
main_fork: Expected SIGTRAP from child
awk: fatal: cannot open file `/proc/350159/maps' for reading: No such file or directory
get_php_bin_path: Failed
```

The message now names the path and which stream it was for, and `main_fork` distinguishes a child that died before exec from the expected SIGTRAP and stops there. I left the defaults alone — relocating people's output files silently seemed worse than the bad message.

### Also: an unchecked short read

`copy_proc_mem` only treated `-1` as failure, so a partial `process_vm_readv` left the tail of the destination struct holding whatever the caller had `memset` it to. `zend_execute_data` and `zend_function` are largely pointers, which are then dereferenced as addresses in the target. Now checked.

### Compatibility

The exit-status change is user-visible: `phpspy -- cmd` goes from always exiting 0 to exiting what `cmd` exited. No existing test depended on it (every child-mode target in the suite exits 0), but it is a CLI contract change and worth a release note if you take it.

### Testing

`make test` passes (15/15) under both `make` and `USE_ZEND=1 make`. `tests/test_child_exit_status.sh` is written standalone rather than through `test.sh`, since the harness has no exit-code assertion — that avoids colliding with #156, which adds one.

Independent of #156 and #157.
