### PR TITLE
Add -N/--max-depth-outer to keep the outermost frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ All with no changes to your application and minimal overhead.
       -i, --time-limit-ms=<ms>           Stop tracing after `ms` milliseconds
                                            (second granularity in pgrep mode)
                                            (default: 0; 0=unlimited)
-      -n, --max-depth=<max>              Set max stack trace depth
-                                           (default: -1; -1=unlimited)
+      -n, --max-depth=<max>              Keep <max> frames from the
+                                           leaf stack frame
+                                           (default: -1; -1=off)
+      -N, --max-depth-outer=<max>        Keep <max> frames from the
+                                           root stack frame
+                                           (default: -1; -1=off)
       -r, --request-info=<opts>          Set request info parts to capture
                                            (q=query c=cookie u=uri p=path
                                            capital=negation)
@@ -94,9 +98,9 @@ All with no changes to your application and minimal overhead.
                                            (default: phpspy.%d.out)
       -E, --child-stderr=<path>          Write child stderr to `path`
                                            (default: phpspy.%d.err)
-      -x, --addr-executor-globals=<hex>  Set address of executor_globals in hex
+          --addr-executor-globals=<hex>  Set address of executor_globals in hex
                                            (default: 0; 0=find dynamically)
-      -a, --addr-sapi-globals=<hex>      Set address of sapi_globals in hex
+          --addr-sapi-globals=<hex>      Set address of sapi_globals in hex
                                            (default: 0; 0=find dynamically)
       -1, --single-line                  Output in single-line mode
       -b, --buffer-size=<size>           Set output buffer size to `size`.
@@ -115,7 +119,7 @@ All with no changes to your application and minimal overhead.
       -c, --continue-on-error            Attempt to continue tracing after
                                            encountering an error
       -q, --quiet                        Suppress errors and warnings on stderr
-      -w, --libname-awk-patt=<patt>      Awk pattern to match name of PHP lib
+          --libname-awk-patt=<patt>      Awk pattern to match name of PHP lib
                                            (default: libphp[78]?)
       -#, --comment=<any>                Ignored; intended for self-documenting
                                            commands
@@ -123,9 +127,9 @@ All with no changes to your application and minimal overhead.
       -v, --version                      Print phpspy version and exit
 
     Experimental options:
-      -j, --event-handler=<handler>      Set event handler (fout, callgrind)
+          --event-handler=<handler>      Set event handler (fout, callgrind)
                                            (default: fout)
-      -J, --event-handler-opts=<opts>    Set event handler options
+          --event-handler-opts=<opts>    Set event handler options
                                            (fout: m=use mutex to prevent
                                            interlaced writes on stdout in `-P`
                                            mode)
@@ -136,6 +140,8 @@ All with no changes to your application and minimal overhead.
                                            <varname>@<path>:<lineno>
                                            <varname>@<path>:<start>-<end>
                                            e.g., xyz@/path/to.php:10-20
+      -D, --peek-pdo                     Peek at the SQL and arguments of PDO
+                                           queries. Emits varpeek events.
       -g, --peek-global=<glospec>        Peek at the contents of a global var
                                            located at `glospec`, which has
                                            the format: <global>.<key>

--- a/phpspy.c
+++ b/phpspy.c
@@ -32,7 +32,8 @@ static int opt_capture_req_cookie = 0;
 static int opt_capture_req_uri = 0;
 static int opt_capture_req_path = 0;
 static int opt_capture_mem = 0;
-static int opt_max_stack_depth = -1;
+static int opt_max_stack_depth_from_leaf = -1;
+static int opt_max_stack_depth_from_root = -1;
 static uint64_t opt_trace_limit = 0;
 static char *opt_path_child_out = "phpspy.%d.out";
 static char *opt_path_child_err = "phpspy.%d.err";
@@ -135,8 +136,12 @@ void usage(FILE *fp, int exit_code) {
     fprintf(fp, "  -i, --time-limit-ms=<ms>           Stop tracing after `ms` milliseconds\n");
     fprintf(fp, "                                       (second granularity in pgrep mode)\n");
     fprintf(fp, "                                       (default: %lu; 0=unlimited)\n", opt_time_limit_ms);
-    fprintf(fp, "  -n, --max-depth=<max>              Set max stack trace depth\n");
-    fprintf(fp, "                                       (default: %d; -1=unlimited)\n", opt_max_stack_depth);
+    fprintf(fp, "  -n, --max-depth=<max>              Keep <max> frames from the\n");
+    fprintf(fp, "                                       leaf stack frame\n");
+    fprintf(fp, "                                       (default: %d; -1=off)\n", opt_max_stack_depth_from_leaf);
+    fprintf(fp, "  -N, --max-depth-outer=<max>        Keep <max> frames from the\n");
+    fprintf(fp, "                                       root stack frame\n");
+    fprintf(fp, "                                       (default: %d; -1=off)\n", opt_max_stack_depth_from_root);
     fprintf(fp, "  -r, --request-info=<opts>          Set request info parts to capture\n");
     fprintf(fp, "                                       (q=query c=cookie u=uri p=path\n");
     fprintf(fp, "                                       capital=negation)\n");
@@ -248,6 +253,7 @@ static void parse_opts(int argc, char **argv) {
         { "limit",                 required_argument, NULL, 'l' },
         { "time-limit-ms",         required_argument, NULL, 'i' },
         { "max-depth",             required_argument, NULL, 'n' },
+        { "max-depth-outer",       required_argument, NULL, 'N' },
         { "request-info",          required_argument, NULL, 'r' },
         { "memory-usage",          no_argument,       NULL, 'm' },
         { "output",                required_argument, NULL, 'o' },
@@ -285,7 +291,7 @@ static void parse_opts(int argc, char **argv) {
     while (
         optind < argc
         && argv[optind][0] == '-'
-        && (c = getopt_long(argc, argv, "hp:P:T:te:s:H:V:l:i:n:r:mo:O:E:1b:f:F:d:cq#:@vSe:g:Dt", long_opts, NULL)) != -1
+        && (c = getopt_long(argc, argv, "hp:P:T:te:s:H:V:l:i:n:N:r:mo:O:E:1b:f:F:d:cq#:@vSe:g:Dt", long_opts, NULL)) != -1
     ) {
         switch (c) {
             case 'h': usage(stdout, 0); break;
@@ -297,7 +303,8 @@ static void parse_opts(int argc, char **argv) {
             case 'V': opt_phpv = optarg; break;
             case 'l': opt_trace_limit = strtoull(optarg, NULL, 10); break;
             case 'i': opt_time_limit_ms = strtol_with_min_or_exit("-i", optarg, 0); break;
-            case 'n': opt_max_stack_depth = atoi_with_min_or_exit("-n", optarg, -1); break;
+            case 'n': opt_max_stack_depth_from_leaf = atoi_with_min_or_exit("-n", optarg, -1); break;
+            case 'N': opt_max_stack_depth_from_root = atoi_with_min_or_exit("-N", optarg, 0); break;
             case 'r':
                 for (i = 0; i < strlen(optarg); i++) {
                     switch (optarg[i]) {
@@ -396,6 +403,9 @@ int main_pid(pid_t pid) {
     context.target.pid = pid;
     context.event_handler = opt_event_handler;
     context.event_handler_opts = opt_event_handler_opts;
+    if (opt_max_stack_depth_from_root >= 0) {
+        utarray_new(context.stack_ptrs, &ut_ptr_icd);
+    }
     try(rv, find_addresses(&context.target));
     try(rv, context.event_handler(&context, PHPSPY_TRACE_EVENT_INIT));
 
@@ -486,6 +496,7 @@ int main_pid(pid_t pid) {
         nanosleep(&sleep_time, NULL);
     }
 
+    if (context.stack_ptrs) utarray_free(context.stack_ptrs);
     context.event_handler(&context, PHPSPY_TRACE_EVENT_DEINIT);
 
     /* in pgrep mode, trigger done condition if we went over the trace limit.

--- a/phpspy.h
+++ b/phpspy.h
@@ -53,6 +53,7 @@
 #define PHPSPY_MAX_ARRAY_BUCKETS 128
 #define PHPSPY_MAX_ARRAY_TABLE_SIZE 512
 #define PHPSPY_HASH_FLAG_PACKED (1 << 2)
+#define PHPSPY_MAX_STACK_WALK 1024
 
 enum {
     PHPSPY_OK           = 0,
@@ -178,6 +179,7 @@ typedef struct trace_context_s {
     const char *event_handler_opts;
     char buf[PHPSPY_STR_SIZE];
     size_t buf_len;
+    UT_array *stack_ptrs;
 } trace_context;
 
 typedef struct addr_memo_s {

--- a/phpspy_trace.c
+++ b/phpspy_trace.c
@@ -1,6 +1,8 @@
 #define try_copy_proc_mem(__what, __raddr, __laddr, __size) \
     try(rv, copy_proc_mem(context->target.pid, (__what), (__raddr), (__laddr), (__size)))
 
+static int stack_collect(trace_context *context, zend_execute_data *remote_execute_data);
+static int stack_emit_frame(trace_context *context, zend_execute_data *remote_execute_data, int depth, zend_execute_data **next_out);
 static int trace_stack(trace_context *context, zend_execute_data *remote_execute_data, int *depth);
 static int trace_request_info(trace_context *context);
 static int trace_memory_info(trace_context *context);
@@ -20,17 +22,8 @@ static int sprint_zarray_packed(trace_context *context, int idx, zval *lzval, ch
 static int sprint_pdo_binds(trace_context *context, zend_array *rht, char *buf, size_t buf_size, size_t *buf_len);
 static int sprint_pdo_bind(trace_context *context, zval *lzval, char *buf, size_t buf_size, size_t *buf_len);
 
-/*********************
-    Trace functions
- *********************/
+static int should_stop_trace(int rv);
 
-/**
- * Sample a single execution trace.
- *
- * @param context Trace context
- *
- * @return int Status code
- */
 static int do_trace(trace_context *context) {
     int rv, depth;
     zend_executor_globals executor_globals;
@@ -39,37 +32,24 @@ static int do_trace(trace_context *context) {
     try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_STACK_BEGIN));
 
     rv = PHPSPY_OK;
-    do {
-        #define maybe_break_on_err() do {                      \
-            if (   (rv & PHPSPY_ERR_PID_DEAD) != 0             \
-                || (rv & PHPSPY_ERR_BUF_FULL) != 0             \
-                || (rv != PHPSPY_OK && !opt_continue_on_error) \
-            ) {                                                \
-                goto do_trace_end;                             \
-            }                                                  \
-        } while(0)
+    rv |= trace_stack(context, executor_globals.current_execute_data, &depth);
+    if (should_stop_trace(rv)) goto do_trace_end;
+    if (depth < 1) goto do_trace_end;
 
-        rv |= trace_stack(context, executor_globals.current_execute_data, &depth);
-        maybe_break_on_err();
-        if (depth < 1) break;
+    if (opt_capture_req) {
+        rv |= trace_request_info(context);
+        if (should_stop_trace(rv)) goto do_trace_end;
+    }
 
-        if (opt_capture_req) {
-            rv |= trace_request_info(context);
-            maybe_break_on_err();
-        }
+    if (opt_capture_mem) {
+        rv |= trace_memory_info(context);
+        if (should_stop_trace(rv)) goto do_trace_end;
+    }
 
-        if (opt_capture_mem) {
-            rv |= trace_memory_info(context);
-            maybe_break_on_err();
-        }
-
-        if (HASH_CNT(hh, glopeek_map) > 0) {
-            rv |= trace_globals(context);
-            maybe_break_on_err();
-        }
-
-        #undef maybe_break_on_err
-    } while (0);
+    if (HASH_CNT(hh, glopeek_map) > 0) {
+        rv |= trace_globals(context);
+        if (should_stop_trace(rv)) goto do_trace_end;
+    }
 
 do_trace_end:
     if (rv == PHPSPY_OK || opt_continue_on_error) {
@@ -88,7 +68,27 @@ do_trace_end:
  *
  * @return int Status code
  */
-static int trace_stack(trace_context *context, zend_execute_data *remote_execute_data, int *depth) {
+static int stack_collect(trace_context *context, zend_execute_data *remote) {
+    int rv;
+    zend_execute_data *next;
+    utarray_clear(context->stack_ptrs);
+    while (remote) {
+        if (utarray_len(context->stack_ptrs) >= PHPSPY_MAX_STACK_WALK) {
+            log_error("stack_collect: stack walk limit (%d) reached\n", PHPSPY_MAX_STACK_WALK);
+            break;
+        }
+        utarray_push_back(context->stack_ptrs, &remote);
+        try_copy_proc_mem(
+            "prev_execute_data",
+            ((char *)remote) + offsetof(zend_execute_data, prev_execute_data),
+            &next, sizeof(next)
+        );
+        remote = next;
+    }
+    return PHPSPY_OK;
+}
+
+static int stack_emit_frame(trace_context *context, zend_execute_data *remote, int depth, zend_execute_data **next_out) {
     int rv;
     zend_execute_data execute_data;
     zend_function zfunc;
@@ -100,50 +100,92 @@ static int trace_stack(trace_context *context, zend_execute_data *remote_execute
 
     target = &context->target;
     frame = &context->event.frame;
+
+    memset(&execute_data, 0, sizeof(execute_data));
+    memset(&zfunc, 0, sizeof(zfunc));
+    memset(&zstring, 0, sizeof(zstring));
+    memset(&zce, 0, sizeof(zce));
+    memset(&zop, 0, sizeof(zop));
+
+    try_copy_proc_mem("execute_data", remote, &execute_data, sizeof(execute_data));
+    try_copy_proc_mem("zfunc", execute_data.func, &zfunc, sizeof(zfunc));
+    if (zfunc.common.function_name) {
+        try(rv, sprint_zstring(context, "function_name", zfunc.common.function_name, frame->loc.func, sizeof(frame->loc.func), &frame->loc.func_len));
+    } else {
+        frame->loc.func_len = snprintf(frame->loc.func, sizeof(frame->loc.func), "<main>");
+    }
+    if (zfunc.common.scope) {
+        try_copy_proc_mem("zce", zfunc.common.scope, &zce, sizeof(zce));
+        try(rv, sprint_zstring(context, "class_name", zce.name, frame->loc.class, sizeof(frame->loc.class), &frame->loc.class_len));
+    } else {
+        frame->loc.class[0] = '\0';
+        frame->loc.class_len = 0;
+    }
+    if (zfunc.type == 2) {
+        try(rv, sprint_zstring(context, "filename", zfunc.op_array.filename, frame->loc.file, sizeof(frame->loc.file), &frame->loc.file_len));
+        frame->loc.lineno = zfunc.op_array.line_start;
+        if (HASH_CNT(hh, varpeek_map) > 0) {
+            if (copy_proc_mem(target->pid, "opline", (void*)execute_data.opline, &zop, sizeof(zop)) == PHPSPY_OK) {
+                trace_locals(context, &zop, remote, &zfunc.op_array, frame->loc.file, frame->loc.file_len);
+            }
+        }
+    } else {
+        frame->loc.file_len = snprintf(frame->loc.file, sizeof(frame->loc.file), "<internal>");
+        frame->loc.lineno = -1;
+    }
+    frame->depth = depth;
+    try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_FRAME));
+    if (opt_peek_pdo) {
+        trace_pdo(context, remote, &execute_data, frame);
+    }
+    if (next_out) *next_out = execute_data.prev_execute_data;
+    return PHPSPY_OK;
+}
+
+static int trace_stack(trace_context *context, zend_execute_data *remote_execute_data, int *depth) {
+    int rv, i, total_depth, keep_inner, keep_outer_from, num_elided;
+    zend_execute_data **pp;
+    trace_frame *frame;
+
     *depth = 0;
 
-    while (remote_execute_data && *depth != opt_max_stack_depth) { /* TODO make options struct */
-        memset(&execute_data, 0, sizeof(execute_data));
-        memset(&zfunc, 0, sizeof(zfunc));
-        memset(&zstring, 0, sizeof(zstring));
-        memset(&zce, 0, sizeof(zce));
-        memset(&zop, 0, sizeof(zop));
+    if (opt_max_stack_depth_from_root >= 0) {
+        try(rv, stack_collect(context, remote_execute_data));
+        total_depth = utarray_len(context->stack_ptrs);
 
-        /* TODO reduce number of copy calls */
-        try_copy_proc_mem("execute_data", remote_execute_data, &execute_data, sizeof(execute_data));
-        try_copy_proc_mem("zfunc", execute_data.func, &zfunc, sizeof(zfunc));
-        if (zfunc.common.function_name) {
-            try(rv, sprint_zstring(context, "function_name", zfunc.common.function_name, frame->loc.func, sizeof(frame->loc.func), &frame->loc.func_len));
-        } else {
-            frame->loc.func_len = snprintf(frame->loc.func, sizeof(frame->loc.func), "<main>");
+        keep_inner = opt_max_stack_depth_from_leaf >= 0 ? opt_max_stack_depth_from_leaf : 0;
+        keep_outer_from = keep_inner;
+        num_elided = 0;
+        if (keep_inner + opt_max_stack_depth_from_root < total_depth) {
+            keep_outer_from = total_depth - opt_max_stack_depth_from_root;
+            num_elided = keep_outer_from - keep_inner;
         }
-        if (zfunc.common.scope) {
-            try_copy_proc_mem("zce", zfunc.common.scope, &zce, sizeof(zce));
-            try(rv, sprint_zstring(context, "class_name", zce.name, frame->loc.class, sizeof(frame->loc.class), &frame->loc.class_len));
-        } else {
-            frame->loc.class[0] = '\0';
-            frame->loc.class_len = 0;
-        }
-        if (zfunc.type == 2) {
-            try(rv, sprint_zstring(context, "filename", zfunc.op_array.filename, frame->loc.file, sizeof(frame->loc.file), &frame->loc.file_len));
-            frame->loc.lineno = zfunc.op_array.line_start;
-            /* TODO add comments */
-            if (HASH_CNT(hh, varpeek_map) > 0) {
-                if (copy_proc_mem(target->pid, "opline", (void*)execute_data.opline, &zop, sizeof(zop)) == PHPSPY_OK) {
-                    trace_locals(context, &zop, remote_execute_data, &zfunc.op_array, frame->loc.file, frame->loc.file_len);
-                }
+
+        frame = &context->event.frame;
+        for (i = 0; i < total_depth; i++) {
+            if (i == keep_inner && num_elided > 0) {
+                frame->loc.func_len = snprintf(frame->loc.func, sizeof(frame->loc.func), "<elided:%d>", num_elided);
+                frame->loc.class[0] = '\0';
+                frame->loc.class_len = 0;
+                frame->loc.file_len = snprintf(frame->loc.file, sizeof(frame->loc.file), "<elided>");
+                frame->loc.lineno = -1;
+                frame->depth = i;
+                try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_FRAME));
             }
-        } else {
-            frame->loc.file_len = snprintf(frame->loc.file, sizeof(frame->loc.file), "<internal>");
-            frame->loc.lineno = -1;
+            if (i >= keep_inner && i < keep_outer_from) continue;
+            pp = (zend_execute_data **)utarray_eltptr(context->stack_ptrs, (unsigned)i);
+            try(rv, stack_emit_frame(context, *pp, i, NULL));
         }
-        frame->depth = *depth;
-        try(rv, context->event_handler(context, PHPSPY_TRACE_EVENT_FRAME));
-        if (opt_peek_pdo) {
-            trace_pdo(context, remote_execute_data, &execute_data, frame);
+        *depth = total_depth;
+    } else {
+        while (remote_execute_data && *depth != opt_max_stack_depth_from_leaf) {
+            if (*depth >= PHPSPY_MAX_STACK_WALK) {
+                log_error("trace_stack: stack walk limit (%d) reached\n", PHPSPY_MAX_STACK_WALK);
+                break;
+            }
+            try(rv, stack_emit_frame(context, remote_execute_data, *depth, &remote_execute_data));
+            *depth += 1;
         }
-        remote_execute_data = execute_data.prev_execute_data;
-        *depth += 1;
     }
 
     return PHPSPY_OK;
@@ -773,3 +815,12 @@ static int sprint_pdo_bind(trace_context *context, zval *lzval, char *buf, size_
     *buf_len = (size_t)(buf - obuf);
     return PHPSPY_OK;
 }
+
+#ifndef PHPSPY_TRACE_ONCE
+#define PHPSPY_TRACE_ONCE
+static int should_stop_trace(int rv) {
+    return (rv & PHPSPY_ERR_PID_DEAD) != 0
+        || (rv & PHPSPY_ERR_BUF_FULL) != 0
+        || (rv != PHPSPY_OK && !opt_continue_on_error);
+}
+#endif

--- a/phpspy_trace_tpl.c
+++ b/phpspy_trace_tpl.c
@@ -20,6 +20,8 @@
 #define pdo_bound_param_data  concat2(pdo_bound_param_data_,  phpv)
 
 #define do_trace              concat2(do_trace_,              phpv)
+#define stack_collect         concat2(stack_collect_,         phpv)
+#define stack_emit_frame      concat2(stack_emit_frame_,      phpv)
 #define trace_stack           concat2(trace_stack_,           phpv)
 #define trace_request_info    concat2(trace_request_info_,    phpv)
 #define trace_memory_info     concat2(trace_memory_info_,     phpv)
@@ -61,6 +63,8 @@
 #undef pdo_bound_param_data
 
 #undef do_trace
+#undef stack_collect
+#undef stack_emit_frame
 #undef trace_stack
 #undef trace_request_info
 #undef trace_memory_info

--- a/tests/test_flamegraph.sh
+++ b/tests/test_flamegraph.sh
@@ -16,14 +16,14 @@ _run() {
         | "$repo/stackcollapse-phpspy.pl" \
         | "$repo/vendor/flamegraph.pl" \
         > "$flame_svg"
-    test_assert_re "flamegraph (qcup)" '\d+ samples' "$(cat "$flame_svg")"
+    test_assert_re "flamegraph_qcup" '\d+ samples' "$(cat "$flame_svg")"
 
     "$PHPSPY" -O/dev/null -E/dev/null --request-info=QCUP 2>/dev/null \
         -- "${PHP[@]}" -r 'sleep(2);' \
         | "$repo/stackcollapse-phpspy.pl" \
         | "$repo/vendor/flamegraph.pl" \
         > "$flame_svg"
-    test_assert_re "flamegraph (QCUP)" '\d+ samples' "$(cat "$flame_svg")"
+    test_assert_re "flamegraph_QCUP" '\d+ samples' "$(cat "$flame_svg")"
 }
 test_fn=_run
 test_invoke

--- a/tests/test_max_depth_outer.sh
+++ b/tests/test_max_depth_outer.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# shellcheck disable=SC2034 # ignore seemingly unused test_invoke params
+# shellcheck disable=SC2016 # ignore $var in single quote strings
+# shellcheck source=/dev/null
+source "$TEST_SH"
+
+php_src='function f($n){ if($n) f($n-1); else usleep(2000000); } f(20);'
+
+# -n alone: keep 2 frames from the leaf; no elision, no root
+phpspy_opts=(--max-depth=2 -- "${PHP[@]}" -r "$php_src")
+declare -A expected not_expected
+expected[n_frame_0]='^0 usleep <internal>:-1$'
+expected[n_frame_1]='^1 f Command line code:1$'
+not_expected[n_no_marker]='^\d+ <elided'
+not_expected[n_no_root]='^22 <main>'
+test_invoke
+
+# -N alone: keep 2 frames from the root; marker at depth 0, leaf absent
+phpspy_opts=(--max-depth-outer=2 -- "${PHP[@]}" -r "$php_src")
+declare -A expected not_expected
+expected[N_marker_at_0]='^0 <elided:\d+> <elided>:-1$'
+expected[N_frame_21]='^21 f Command line code:1$'
+expected[N_frame_22]='^22 <main>'
+not_expected[N_no_leaf]='^0 usleep <internal>:-1$'
+test_invoke
+
+# -n 2 -N 2: elides the middle (2+2=4 < 23 frames)
+phpspy_opts=(--max-depth=2 --max-depth-outer=2 -- "${PHP[@]}" -r "$php_src")
+declare -A expected not_expected
+expected[mid_frame_0]='^0 usleep <internal>:-1$'
+expected[mid_frame_1]='^1 f Command line code:1$'
+expected[mid_marker]='^2 <elided:\d+> <elided>:-1$'
+expected[mid_frame_21]='^21 f Command line code:1$'
+expected[mid_frame_22]='^22 <main>'
+not_expected[mid_no_frame_2]='^2 f Command line code:1$'
+test_invoke
+
+# -n 11 -N 12: exactly fits 23 frames (11+12=23), no elision
+phpspy_opts=(--max-depth=11 --max-depth-outer=12 -- "${PHP[@]}" -r "$php_src")
+declare -A expected not_expected
+expected[exact_frame_0]='^0 usleep <internal>:-1$'
+expected[exact_frame_10]='^10 f Command line code:1$'
+expected[exact_frame_11]='^11 f Command line code:1$'
+expected[exact_frame_22]='^22 <main>'
+not_expected[exact_no_marker]='^\d+ <elided'
+test_invoke
+
+# -n 15 -N 15: overlapping (15+15=30 > 23), all frames, no elision
+phpspy_opts=(--max-depth=15 --max-depth-outer=15 -- "${PHP[@]}" -r "$php_src")
+declare -A expected not_expected
+expected[over_frame_0]='^0 usleep <internal>:-1$'
+expected[over_frame_22]='^22 <main>'
+not_expected[over_no_marker]='^\d+ <elided'
+test_invoke

--- a/tests/test_varpeek.sh
+++ b/tests/test_varpeek.sh
@@ -15,7 +15,7 @@ php_file=$(mktemp)
 echo "$php_src" >"$php_file"
 phpspy_opts=(--limit=0 --peek-var "a@$php_file:4" -- "${PHP[@]}" "$php_file")
 declare -A expected
-expected[varpeek        ]="^# varpeek a@$php_file:4 = 42"
+expected[varpeek1       ]="^# varpeek a@$php_file:4 = 42"
 test_invoke
 rm -f "$php_file"
 
@@ -31,6 +31,6 @@ php_file=$(mktemp)
 echo "$php_src" >"$php_file"
 phpspy_opts=(--limit=0 --peek-var "a@$php_file:4" -- "${PHP[@]}" "$php_file")
 declare -A expected
-expected[varpeek        ]="^# varpeek a@$php_file:4 = k=42,j=dolphin$"
+expected[varpeek2       ]="^# varpeek a@$php_file:4 = k=42,j=dolphin$"
 test_invoke
 rm -f "$php_file"


### PR DESCRIPTION
https://github.com/adsr/phpspy/pull/160 with some merge conflicts fixed, and one perf optimization. (With -N, we save the stack frame pointers when measuring depth, so we don't have to remote copy them again.) 