### PR TITLE
Child mode: report the child's exit status, and say why it failed

### DIFF
--- a/phpspy.c
+++ b/phpspy.c
@@ -470,7 +470,12 @@ int main_pid(pid_t pid) {
         if (opt_pause) rv |= unpause_pid(pid);
 
         /* bail if pid died */
-        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) break;
+        if ((rv & PHPSPY_ERR_PID_DEAD) != 0) {
+            if (!in_pgrep_mode) {
+                log_error("main_pid: pid %d exited\n", (int)pid);
+            }
+            break;
+        }
 
         /* maybe apply trace limit */
         if (opt_trace_limit > 0 && rv == PHPSPY_OK) {
@@ -525,13 +530,34 @@ static int main_fork(int argc, char **argv) {
         log_perror("fork");
         exit(1);
     }
-    waitpid(fork_pid, &status, 0);
+    if (waitpid(fork_pid, &status, 0) < 0) {
+        log_perror("main_fork: waitpid");
+        return PHPSPY_ERR;
+    }
+
+    if (WIFEXITED(status)) {
+        log_error("main_fork: Child exited with status %d before exec\n", WEXITSTATUS(status));
+        return WEXITSTATUS(status) != 0 ? WEXITSTATUS(status) : 1;
+    }
+    if (WIFSIGNALED(status)) {
+        log_error("main_fork: Child killed by signal %d before exec\n", WTERMSIG(status));
+        return 128 + WTERMSIG(status);
+    }
     if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP) {
         log_error("main_fork: Expected SIGTRAP from child\n");
     }
+
     ptrace(PTRACE_DETACH, fork_pid, NULL, NULL);
     rv = main_pid(fork_pid);
-    waitpid(fork_pid, NULL, 0);
+    waitpid(fork_pid, &status, 0);
+
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+
     return rv;
 }
 
@@ -601,7 +627,12 @@ static void redirect_child_stdio(int proc_fd, char *opt_path) {
         }
     }
     if ((redir_file = fopen(redir_path, "w")) == NULL) {
-        log_perror("fopen");
+        log_error(
+            "redirect_child_stdio: Failed to open '%s' for child %s (%s)\n",
+            redir_path,
+            proc_fd == STDOUT_FILENO ? "stdout (-O)" : "stderr (-E)",
+            strerror(errno)
+        );
         free(redir_path);
         exit(1);
     }
@@ -755,6 +786,7 @@ static void glopeek_add(char *glospec) {
 static int copy_proc_mem(pid_t pid, const char *what, void *raddr, void *laddr, size_t size) {
     struct iovec local[1];
     struct iovec remote[1];
+    ssize_t nread;
 
     if (raddr == NULL) {
         log_error("copy_proc_mem: Not copying %s; raddr is NULL\n", what);
@@ -766,12 +798,18 @@ static int copy_proc_mem(pid_t pid, const char *what, void *raddr, void *laddr, 
     remote[0].iov_base = raddr;
     remote[0].iov_len = size;
 
-    if (process_vm_readv(pid, local, 1, remote, 1, 0) == -1) {
-        if (errno == ESRCH) { /* No such process */
-            log_perror("process_vm_readv");
+    nread = process_vm_readv(pid, local, 1, remote, 1, 0);
+
+    if (nread == -1) {
+        if (errno == ESRCH) {
             return PHPSPY_ERR | PHPSPY_ERR_PID_DEAD;
         }
         log_error("copy_proc_mem: Failed to copy %s; err=%s raddr=%p size=%lu\n", what, strerror(errno), raddr, size);
+        return PHPSPY_ERR;
+    }
+
+    if ((size_t)nread != size) {
+        log_error("copy_proc_mem: Partial read of %s; got %ld of %lu bytes; raddr=%p\n", what, (long)nread, size, raddr);
         return PHPSPY_ERR;
     }
 

--- a/tests/test_child_exit_status.sh
+++ b/tests/test_child_exit_status.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# shellcheck disable=SC2034 # ignore seemingly unused test_invoke params
+# shellcheck source=/dev/null
+source "$TEST_SH"
+
+# exit 0: phpspy propagates child exit status
+_exit_0() {
+    "$PHPSPY" --limit=0 --quiet -O/dev/null -E/dev/null -o /dev/null \
+        -- "${PHP[@]}" -r 'exit(0);' >/dev/null 2>&1
+    test_assert exit_0 0 $?
+}
+test_fn=_exit_0
+need_ptrace=1
+test_invoke
+
+# exit 3: non-zero status preserved
+_exit_3() {
+    "$PHPSPY" --limit=0 --quiet -O/dev/null -E/dev/null -o /dev/null \
+        -- "${PHP[@]}" -r 'exit(3);' >/dev/null 2>&1
+    test_assert exit_3 3 $?
+}
+test_fn=_exit_3
+need_ptrace=1
+test_invoke
+
+# signal: exit status is 128 + signal number (SIGTERM=15, expect 143)
+_signalled() {
+    "$PHPSPY" --limit=0 --quiet -O/dev/null -E/dev/null -o /dev/null \
+        -- "${PHP[@]}" \
+        -r 'posix_kill(posix_getpid(), SIGTERM); usleep(5000000);' \
+        >/dev/null 2>&1
+    test_assert signalled 143 $?
+}
+if "${PHP[@]}" -r 'exit(function_exists("posix_kill") ? 0 : 1);' 2>/dev/null; then
+    test_fn=_signalled
+else
+    skip='ext/posix not available'
+fi
+need_ptrace=1
+test_invoke
+
+# outlives sampling: phpspy stops first, child exits later with its status
+_outlives_sampling() {
+    "$PHPSPY" --limit=0 --time-limit-ms=500 --quiet \
+        -O/dev/null -E/dev/null -o /dev/null \
+        -- "${PHP[@]}" -r 'usleep(1500000); exit(7);' >/dev/null 2>&1
+    test_assert outlives_sampling 7 $?
+}
+test_fn=_outlives_sampling
+need_ptrace=1
+use_timeout_s=10
+test_invoke
+
+# bad -E path: error names the path; child not probed as a zombie
+_bad_stderr_path() {
+    local err
+    err=$(
+        "$PHPSPY" --limit=0 -O/dev/null -E/nonexistent-dir/x.err -o /dev/null \
+            -- "${PHP[@]}" -r 'usleep(100000);' 2>&1 >/dev/null
+    )
+    test_assert_re bad_stderr_names_path 'nonexistent-dir/x\.err' "$err"
+    test_assert bad_stderr_no_probe 0 "$(grep -c 'get_php_bin_path' <<<"$err")"
+}
+test_fn=_bad_stderr_path
+need_ptrace=1
+test_invoke


### PR DESCRIPTION
https://github.com/adsr/phpspy/pull/158 with merge conflicts fixed and the test changed to fit new test pattern.